### PR TITLE
feat(graph): add statum-graph export crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [workspace]
 resolver = "2"
-members = ["module_path_extractor", "macro_registry", "statum-core", "statum-macros", "statum", "statum-examples"]
+members = [
+    "module_path_extractor",
+    "macro_registry",
+    "statum-core",
+    "statum-macros",
+    "statum",
+    "statum-examples",
+    "statum-graph",
+]
 
 [patch.crates-io]
 module_path_extractor = { path = "module_path_extractor" }
@@ -10,5 +18,5 @@ statum = { path = "statum" }
 
 [workspace.metadata.scripts]
 version-bump = "cargo script scripts/update_version.rs -- 1.0.0"
-publish = "cargo publish -p module_path_extractor && cargo publish -p macro_registry && cargo publish -p statum-core && cargo publish -p statum-macros && cargo publish -p statum"
+publish = "cargo publish -p module_path_extractor && cargo publish -p macro_registry && cargo publish -p statum-core && cargo publish -p statum-macros && cargo publish -p statum && cargo publish -p statum-graph"
 publish-dry-run = "bash scripts/check_publish_dry_run.sh"

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ See [docs/introspection.md](docs/introspection.md) for the full guide and
 [statum-examples/src/toy_demos/16-machine-introspection.rs](statum-examples/src/toy_demos/16-machine-introspection.rs)
 for a runnable example.
 
+If you want a ready-made renderer for that graph surface, the workspace also
+ships [statum-graph](statum-graph/README.md), which exports machine-local
+topology and Mermaid output directly from `MachineIntrospection::GRAPH`.
+
 For source-local labels and descriptions, use `#[present(...)]` on the machine,
 state variants, and transition methods. If you also want typed metadata in the
 generated `machine::PRESENTATION` constant, declare

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -91,6 +91,10 @@ From there, a consumer can ask for:
 - a transition by source state and method name
 - the exact legal targets for a transition site
 
+If you want a ready-made static graph export instead of writing your own
+renderer, `statum-graph` builds `MachineDoc` values and Mermaid output directly
+from this graph surface.
+
 ## Transition Identity
 
 State ids are generated as a machine-scoped enum like `flow::StateId`.

--- a/statum-graph/Cargo.toml
+++ b/statum-graph/Cargo.toml
@@ -1,0 +1,26 @@
+[dependencies.statum]
+path = "../statum"
+version = "0.6.9"
+
+[dev-dependencies]
+insta = "1.43"
+
+[package]
+authors = ["Eran Boodnero <eran@eran.codes>"]
+categories = ["development-tools", "rust-patterns"]
+description = "Static graph export for Statum machine introspection"
+documentation = "https://docs.rs/statum-graph"
+edition = "2021"
+keywords = [
+    "typestate",
+    "graph",
+    "mermaid",
+    "workflow",
+    "state-machine",
+]
+license = "MIT"
+name = "statum-graph"
+readme = "README.md"
+repository = "https://github.com/eboody/statum"
+rust-version = "1.93"
+version = "0.6.9"

--- a/statum-graph/README.md
+++ b/statum-graph/README.md
@@ -1,0 +1,76 @@
+# statum-graph
+
+`statum-graph` exports static machine topology directly from
+`statum::MachineIntrospection::GRAPH`.
+
+It is authoritative only for machine-local structure:
+
+- machine identity
+- states
+- transition sites
+- exact legal targets
+- roots derivable from the static graph itself
+
+It does not model runtime-selected branches, orchestration across multiple
+machines, or consumer-owned explanation metadata.
+
+## Install
+
+```toml
+[dependencies]
+statum = "0.6.9"
+statum-graph = "0.6.9"
+```
+
+## Example
+
+```rust
+use statum::{machine, state, transition};
+use statum_graph::{render, MachineDoc};
+
+#[state]
+enum FlowState {
+    Draft,
+    Review,
+    Accepted,
+    Rejected,
+}
+
+#[machine]
+struct Flow<FlowState> {}
+
+#[transition]
+impl Flow<Draft> {
+    fn submit(self) -> Flow<Review> {
+        self.transition()
+    }
+}
+
+#[transition]
+impl Flow<Review> {
+    fn decide(
+        self,
+        accept: bool,
+    ) -> ::core::result::Result<Flow<Accepted>, Flow<Rejected>> {
+        if accept {
+            Ok(self.accept())
+        } else {
+            Err(self.reject())
+        }
+    }
+
+    fn accept(self) -> Flow<Accepted> {
+        self.transition()
+    }
+
+    fn reject(self) -> Flow<Rejected> {
+        self.transition()
+    }
+}
+
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+let mermaid = render::mermaid(&doc);
+
+assert!(mermaid.contains("s1 -->|decide| s2"));
+assert!(mermaid.contains("s1 -->|decide| s3"));
+```

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -176,8 +176,9 @@ where
 
     /// Exports one externally supplied machine graph after validating it.
     pub fn try_from_graph(graph: &'static MachineGraph<S, T>) -> Result<Self, MachineDocError> {
-        validate_graph(graph)?;
-        let incoming = incoming_states(graph);
+        let transitions = graph.transitions.as_slice();
+        validate_graph(graph.machine, graph.states, transitions)?;
+        let incoming = incoming_states(transitions);
         let state_positions = state_positions(graph.states);
 
         let states = graph
@@ -190,8 +191,7 @@ where
             })
             .collect();
 
-        let mut edges = graph
-            .transitions
+        let mut edges = transitions
             .iter()
             .copied()
             .map(|descriptor| EdgeDoc { descriptor })
@@ -222,27 +222,31 @@ pub struct EdgeDoc<S: 'static, T: 'static> {
     pub descriptor: TransitionDescriptor<S, T>,
 }
 
-fn validate_graph<S, T>(graph: &MachineGraph<S, T>) -> Result<(), MachineDocError>
+fn validate_graph<S, T>(
+    machine: MachineDescriptor,
+    states: &[StateDescriptor<S>],
+    transitions: &[TransitionDescriptor<S, T>],
+) -> Result<(), MachineDocError>
 where
     S: Copy + Eq + std::hash::Hash + 'static,
     T: Copy + Eq + 'static,
 {
-    let mut state_names = HashMap::with_capacity(graph.states.len());
-    for state in graph.states.iter() {
+    let mut state_names = HashMap::with_capacity(states.len());
+    for state in states.iter() {
         if state_names.insert(state.id, state.rust_name).is_some() {
             return Err(MachineDocError::DuplicateStateId {
-                machine: graph.machine.rust_type_path,
+                machine: machine.rust_type_path,
                 state: state.rust_name,
             });
         }
     }
 
-    let mut transition_sites = HashSet::with_capacity(graph.transitions.len());
-    let mut transition_ids = Vec::with_capacity(graph.transitions.len());
-    for transition in graph.transitions.iter() {
+    let mut transition_sites = HashSet::with_capacity(transitions.len());
+    let mut transition_ids = Vec::with_capacity(transitions.len());
+    for transition in transitions.iter() {
         if transition_ids.contains(&transition.id) {
             return Err(MachineDocError::DuplicateTransitionId {
-                machine: graph.machine.rust_type_path,
+                machine: machine.rust_type_path,
                 transition: transition.method_name,
             });
         }
@@ -250,7 +254,7 @@ where
 
         if !state_names.contains_key(&transition.from) {
             return Err(MachineDocError::MissingSourceState {
-                machine: graph.machine.rust_type_path,
+                machine: machine.rust_type_path,
                 transition: transition.method_name,
             });
         }
@@ -258,7 +262,7 @@ where
         let from_state_name = state_names[&transition.from];
         if !transition_sites.insert((transition.from, transition.method_name)) {
             return Err(MachineDocError::DuplicateTransitionSite {
-                machine: graph.machine.rust_type_path,
+                machine: machine.rust_type_path,
                 state: from_state_name,
                 transition: transition.method_name,
             });
@@ -268,14 +272,14 @@ where
         for target in transition.to.iter().copied() {
             let Some(state_name) = state_names.get(&target).copied() else {
                 return Err(MachineDocError::MissingTargetState {
-                    machine: graph.machine.rust_type_path,
+                    machine: machine.rust_type_path,
                     transition: transition.method_name,
                 });
             };
 
             if !seen_targets.insert(target) {
                 return Err(MachineDocError::DuplicateTargetState {
-                    machine: graph.machine.rust_type_path,
+                    machine: machine.rust_type_path,
                     transition: transition.method_name,
                     state: state_name,
                 });
@@ -286,13 +290,13 @@ where
     Ok(())
 }
 
-fn incoming_states<S, T>(graph: &MachineGraph<S, T>) -> HashSet<S>
+fn incoming_states<S, T>(transitions: &[TransitionDescriptor<S, T>]) -> HashSet<S>
 where
     S: Copy + Eq + std::hash::Hash + 'static,
     T: Copy + Eq + 'static,
 {
     let mut incoming = HashSet::new();
-    for transition in graph.transitions.iter() {
+    for transition in transitions.iter() {
         for target in transition.to.iter().copied() {
             incoming.insert(target);
         }

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -30,6 +30,11 @@ pub struct MachineDoc<S: 'static, T: 'static> {
 /// Error returned when a `MachineGraph` cannot be exported into a `MachineDoc`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MachineDocError {
+    /// One state id appears more than once in the graph's state list.
+    DuplicateStateId {
+        machine: &'static str,
+        state: &'static str,
+    },
     /// One transition source state is not present in the graph's state list.
     MissingSourceState {
         machine: &'static str,
@@ -45,6 +50,10 @@ pub enum MachineDocError {
 impl core::fmt::Display for MachineDocError {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::DuplicateStateId { machine, state } => write!(
+                formatter,
+                "machine graph `{machine}` contains duplicate state id for state `{state}`"
+            ),
             Self::MissingSourceState {
                 machine,
                 transition,
@@ -175,11 +184,21 @@ pub struct EdgeDoc<S: 'static, T: 'static> {
 
 fn validate_graph<S, T>(graph: &MachineGraph<S, T>) -> Result<(), MachineDocError>
 where
-    S: Copy + Eq + 'static,
+    S: Copy + Eq + std::hash::Hash + 'static,
     T: Copy + Eq + 'static,
 {
+    let mut state_ids = HashSet::with_capacity(graph.states.len());
+    for state in graph.states.iter() {
+        if !state_ids.insert(state.id) {
+            return Err(MachineDocError::DuplicateStateId {
+                machine: graph.machine.rust_type_path,
+                state: state.rust_name,
+            });
+        }
+    }
+
     for transition in graph.transitions.iter() {
-        if graph.state(transition.from).is_none() {
+        if !state_ids.contains(&transition.from) {
             return Err(MachineDocError::MissingSourceState {
                 machine: graph.machine.rust_type_path,
                 transition: transition.method_name,
@@ -190,7 +209,7 @@ where
             .to
             .iter()
             .copied()
-            .any(|target| graph.state(target).is_none())
+            .any(|target| !state_ids.contains(&target))
         {
             return Err(MachineDocError::MissingTargetState {
                 machine: graph.machine.rust_type_path,

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -22,12 +22,93 @@ pub mod render;
 /// from the static graph itself.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MachineDoc<S: 'static, T: 'static> {
+    machine: MachineDescriptor,
+    states: Vec<StateDoc<S>>,
+    edges: Vec<EdgeDoc<S, T>>,
+}
+
+/// Error returned when a `MachineGraph` cannot be exported into a `MachineDoc`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MachineDocError {
+    /// One transition source state is not present in the graph's state list.
+    MissingSourceState {
+        machine: &'static str,
+        transition: &'static str,
+    },
+    /// One transition target state is not present in the graph's state list.
+    MissingTargetState {
+        machine: &'static str,
+        transition: &'static str,
+    },
+}
+
+impl core::fmt::Display for MachineDocError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingSourceState {
+                machine,
+                transition,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains transition `{transition}` whose source state is missing from the state list"
+            ),
+            Self::MissingTargetState {
+                machine,
+                transition,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains transition `{transition}` whose target state is missing from the state list"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MachineDocError {}
+
+impl<S, T> TryFrom<&'static MachineGraph<S, T>> for MachineDoc<S, T>
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+    T: Copy + Eq + 'static,
+{
+    type Error = MachineDocError;
+
+    fn try_from(graph: &'static MachineGraph<S, T>) -> Result<Self, Self::Error> {
+        Self::try_from_graph(graph)
+    }
+}
+
+impl<S, T> MachineDoc<S, T> {
     /// Descriptor for the exported machine family.
-    pub machine: MachineDescriptor,
+    pub fn machine(&self) -> MachineDescriptor {
+        self.machine
+    }
+
     /// Exported states in the same order as the underlying static graph.
-    pub states: Vec<StateDoc<S>>,
+    pub fn states(&self) -> &[StateDoc<S>] {
+        &self.states
+    }
+
     /// Exported transition sites sorted stably for deterministic renderers.
-    pub edges: Vec<EdgeDoc<S, T>>,
+    pub fn edges(&self) -> &[EdgeDoc<S, T>] {
+        &self.edges
+    }
+}
+
+impl<S, T> MachineDoc<S, T>
+where
+    S: Copy + Eq + 'static,
+{
+    /// Returns the exported state descriptor for one generated state id.
+    pub fn state(&self, id: S) -> Option<&StateDoc<S>> {
+        self.states.iter().find(|state| state.descriptor.id == id)
+    }
+}
+
+impl<S, T> MachineDoc<S, T> {
+    /// Returns every state with no incoming edge in the exported topology.
+    pub fn roots(&self) -> impl Iterator<Item = &StateDoc<S>> {
+        self.states.iter().filter(|state| state.is_root)
+    }
 }
 
 impl<S, T> MachineDoc<S, T>
@@ -40,11 +121,13 @@ where
     where
         M: MachineIntrospection<StateId = S, TransitionId = T>,
     {
-        Self::from_graph(M::GRAPH)
+        Self::try_from_graph(M::GRAPH)
+            .expect("Statum emitted an invalid MachineIntrospection::GRAPH")
     }
 
-    /// Exports one machine graph from a static `MachineGraph`.
-    pub fn from_graph(graph: &'static MachineGraph<S, T>) -> Self {
+    /// Exports one externally supplied machine graph after validating it.
+    pub fn try_from_graph(graph: &'static MachineGraph<S, T>) -> Result<Self, MachineDocError> {
+        validate_graph(graph)?;
         let incoming = incoming_states(graph);
         let state_positions = state_positions(graph.states);
 
@@ -66,21 +149,11 @@ where
             .collect::<Vec<_>>();
         edges.sort_by(|left, right| compare_edges(&state_positions, left, right));
 
-        Self {
+        Ok(Self {
             machine: graph.machine,
             states,
             edges,
-        }
-    }
-
-    /// Returns the exported state descriptor for one generated state id.
-    pub fn state(&self, id: S) -> Option<&StateDoc<S>> {
-        self.states.iter().find(|state| state.descriptor.id == id)
-    }
-
-    /// Returns every state with no incoming edge in the exported topology.
-    pub fn roots(&self) -> impl Iterator<Item = &StateDoc<S>> {
-        self.states.iter().filter(|state| state.is_root)
+        })
     }
 }
 
@@ -98,6 +171,35 @@ pub struct StateDoc<S: 'static> {
 pub struct EdgeDoc<S: 'static, T: 'static> {
     /// Underlying descriptor from `statum`.
     pub descriptor: TransitionDescriptor<S, T>,
+}
+
+fn validate_graph<S, T>(graph: &MachineGraph<S, T>) -> Result<(), MachineDocError>
+where
+    S: Copy + Eq + 'static,
+    T: Copy + Eq + 'static,
+{
+    for transition in graph.transitions.iter() {
+        if graph.state(transition.from).is_none() {
+            return Err(MachineDocError::MissingSourceState {
+                machine: graph.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        }
+
+        if transition
+            .to
+            .iter()
+            .copied()
+            .any(|target| graph.state(target).is_none())
+        {
+            return Err(MachineDocError::MissingTargetState {
+                machine: graph.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn incoming_states<S, T>(graph: &MachineGraph<S, T>) -> HashSet<S>

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -40,6 +40,12 @@ pub enum MachineDocError {
         machine: &'static str,
         transition: &'static str,
     },
+    /// One source state declares the same transition method name more than once.
+    DuplicateTransitionSite {
+        machine: &'static str,
+        state: &'static str,
+        transition: &'static str,
+    },
     /// One transition source state is not present in the graph's state list.
     MissingSourceState {
         machine: &'static str,
@@ -71,6 +77,14 @@ impl core::fmt::Display for MachineDocError {
             } => write!(
                 formatter,
                 "machine graph `{machine}` contains duplicate transition id for transition `{transition}`"
+            ),
+            Self::DuplicateTransitionSite {
+                machine,
+                state,
+                transition,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains duplicate transition site `{state}::{transition}`"
             ),
             Self::MissingSourceState {
                 machine,
@@ -223,6 +237,7 @@ where
         }
     }
 
+    let mut transition_sites = HashSet::with_capacity(graph.transitions.len());
     let mut transition_ids = Vec::with_capacity(graph.transitions.len());
     for transition in graph.transitions.iter() {
         if transition_ids.contains(&transition.id) {
@@ -236,6 +251,15 @@ where
         if !state_names.contains_key(&transition.from) {
             return Err(MachineDocError::MissingSourceState {
                 machine: graph.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        }
+
+        let from_state_name = state_names[&transition.from];
+        if !transition_sites.insert((transition.from, transition.method_name)) {
+            return Err(MachineDocError::DuplicateTransitionSite {
+                machine: graph.machine.rust_type_path,
+                state: from_state_name,
                 transition: transition.method_name,
             });
         }

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -30,6 +30,8 @@ pub struct MachineDoc<S: 'static, T: 'static> {
 /// Error returned when a `MachineGraph` cannot be exported into a `MachineDoc`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MachineDocError {
+    /// The graph's state list is empty.
+    EmptyStateList { machine: &'static str },
     /// One state id appears more than once in the graph's state list.
     DuplicateStateId {
         machine: &'static str,
@@ -56,6 +58,11 @@ pub enum MachineDocError {
         machine: &'static str,
         transition: &'static str,
     },
+    /// One transition site declares no legal target states.
+    EmptyTargetSet {
+        machine: &'static str,
+        transition: &'static str,
+    },
     /// One transition lists the same target state more than once.
     DuplicateTargetState {
         machine: &'static str,
@@ -67,6 +74,10 @@ pub enum MachineDocError {
 impl core::fmt::Display for MachineDocError {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::EmptyStateList { machine } => write!(
+                formatter,
+                "machine graph `{machine}` contains no states"
+            ),
             Self::DuplicateStateId { machine, state } => write!(
                 formatter,
                 "machine graph `{machine}` contains duplicate state id for state `{state}`"
@@ -99,6 +110,13 @@ impl core::fmt::Display for MachineDocError {
             } => write!(
                 formatter,
                 "machine graph `{machine}` contains transition `{transition}` whose target state is missing from the state list"
+            ),
+            Self::EmptyTargetSet {
+                machine,
+                transition,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains transition `{transition}` with no target states"
             ),
             Self::DuplicateTargetState {
                 machine,
@@ -231,6 +249,12 @@ where
     S: Copy + Eq + std::hash::Hash + 'static,
     T: Copy + Eq + 'static,
 {
+    if states.is_empty() {
+        return Err(MachineDocError::EmptyStateList {
+            machine: machine.rust_type_path,
+        });
+    }
+
     let mut state_names = HashMap::with_capacity(states.len());
     for state in states.iter() {
         if state_names.insert(state.id, state.rust_name).is_some() {
@@ -264,6 +288,13 @@ where
             return Err(MachineDocError::DuplicateTransitionSite {
                 machine: machine.rust_type_path,
                 state: from_state_name,
+                transition: transition.method_name,
+            });
+        }
+
+        if transition.to.is_empty() {
+            return Err(MachineDocError::EmptyTargetSet {
+                machine: machine.rust_type_path,
                 transition: transition.method_name,
             });
         }

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -1,0 +1,160 @@
+//! Static graph export built directly from `statum::MachineIntrospection::GRAPH`.
+//!
+//! This crate is authoritative only for machine-local topology:
+//! machine identity, states, transition sites, exact legal targets, and
+//! roots derivable from the static graph itself.
+//!
+//! It does not model orchestration order across machines, runtime-selected
+//! branches for one run, or any consumer-owned presentation metadata.
+
+use std::collections::{HashMap, HashSet};
+
+use statum::{
+    MachineDescriptor, MachineGraph, MachineIntrospection, StateDescriptor, TransitionDescriptor,
+};
+
+pub mod render;
+
+/// Static machine graph exported directly from `MachineIntrospection::GRAPH`.
+///
+/// This type is authoritative only for machine-local topology:
+/// states, transition sites, exact legal targets, and roots derivable
+/// from the static graph itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MachineDoc<S: 'static, T: 'static> {
+    /// Descriptor for the exported machine family.
+    pub machine: MachineDescriptor,
+    /// Exported states in the same order as the underlying static graph.
+    pub states: Vec<StateDoc<S>>,
+    /// Exported transition sites sorted stably for deterministic renderers.
+    pub edges: Vec<EdgeDoc<S, T>>,
+}
+
+impl<S, T> MachineDoc<S, T>
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+    T: Copy + Eq + 'static,
+{
+    /// Exports one machine family from a concrete `MachineIntrospection` type.
+    pub fn from_machine<M>() -> Self
+    where
+        M: MachineIntrospection<StateId = S, TransitionId = T>,
+    {
+        Self::from_graph(M::GRAPH)
+    }
+
+    /// Exports one machine graph from a static `MachineGraph`.
+    pub fn from_graph(graph: &'static MachineGraph<S, T>) -> Self {
+        let incoming = incoming_states(graph);
+        let state_positions = state_positions(graph.states);
+
+        let states = graph
+            .states
+            .iter()
+            .copied()
+            .map(|descriptor| StateDoc {
+                descriptor,
+                is_root: !incoming.contains(&descriptor.id),
+            })
+            .collect();
+
+        let mut edges = graph
+            .transitions
+            .iter()
+            .copied()
+            .map(|descriptor| EdgeDoc { descriptor })
+            .collect::<Vec<_>>();
+        edges.sort_by(|left, right| compare_edges(&state_positions, left, right));
+
+        Self {
+            machine: graph.machine,
+            states,
+            edges,
+        }
+    }
+
+    /// Returns the exported state descriptor for one generated state id.
+    pub fn state(&self, id: S) -> Option<&StateDoc<S>> {
+        self.states.iter().find(|state| state.descriptor.id == id)
+    }
+
+    /// Returns every state with no incoming edge in the exported topology.
+    pub fn roots(&self) -> impl Iterator<Item = &StateDoc<S>> {
+        self.states.iter().filter(|state| state.is_root)
+    }
+}
+
+/// Exported state metadata for one graph node.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StateDoc<S: 'static> {
+    /// Underlying descriptor from `statum`.
+    pub descriptor: StateDescriptor<S>,
+    /// True when the exported topology has no incoming edge for this state.
+    pub is_root: bool,
+}
+
+/// Exported transition metadata for one graph edge site.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EdgeDoc<S: 'static, T: 'static> {
+    /// Underlying descriptor from `statum`.
+    pub descriptor: TransitionDescriptor<S, T>,
+}
+
+fn incoming_states<S, T>(graph: &MachineGraph<S, T>) -> HashSet<S>
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+    T: Copy + Eq + 'static,
+{
+    let mut incoming = HashSet::new();
+    for transition in graph.transitions.iter() {
+        for target in transition.to.iter().copied() {
+            incoming.insert(target);
+        }
+    }
+
+    incoming
+}
+
+fn state_positions<S>(states: &[StateDescriptor<S>]) -> HashMap<S, usize>
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+{
+    states
+        .iter()
+        .enumerate()
+        .map(|(index, state)| (state.id, index))
+        .collect()
+}
+
+fn compare_edges<S, T>(
+    state_positions: &HashMap<S, usize>,
+    left: &EdgeDoc<S, T>,
+    right: &EdgeDoc<S, T>,
+) -> std::cmp::Ordering
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+    T: Copy + Eq + 'static,
+{
+    state_positions[&left.descriptor.from]
+        .cmp(&state_positions[&right.descriptor.from])
+        .then_with(|| {
+            left.descriptor
+                .method_name
+                .cmp(right.descriptor.method_name)
+        })
+        .then_with(|| compare_targets(state_positions, left.descriptor.to, right.descriptor.to))
+}
+
+fn compare_targets<S>(
+    state_positions: &HashMap<S, usize>,
+    left: &[S],
+    right: &[S],
+) -> std::cmp::Ordering
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+{
+    let left = left.iter().map(|state| state_positions[state]);
+    let right = right.iter().map(|state| state_positions[state]);
+
+    left.cmp(right)
+}

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -35,6 +35,11 @@ pub enum MachineDocError {
         machine: &'static str,
         state: &'static str,
     },
+    /// One transition id appears more than once in the graph's transition list.
+    DuplicateTransitionId {
+        machine: &'static str,
+        transition: &'static str,
+    },
     /// One transition source state is not present in the graph's state list.
     MissingSourceState {
         machine: &'static str,
@@ -45,6 +50,12 @@ pub enum MachineDocError {
         machine: &'static str,
         transition: &'static str,
     },
+    /// One transition lists the same target state more than once.
+    DuplicateTargetState {
+        machine: &'static str,
+        transition: &'static str,
+        state: &'static str,
+    },
 }
 
 impl core::fmt::Display for MachineDocError {
@@ -53,6 +64,13 @@ impl core::fmt::Display for MachineDocError {
             Self::DuplicateStateId { machine, state } => write!(
                 formatter,
                 "machine graph `{machine}` contains duplicate state id for state `{state}`"
+            ),
+            Self::DuplicateTransitionId {
+                machine,
+                transition,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains duplicate transition id for transition `{transition}`"
             ),
             Self::MissingSourceState {
                 machine,
@@ -67,6 +85,14 @@ impl core::fmt::Display for MachineDocError {
             } => write!(
                 formatter,
                 "machine graph `{machine}` contains transition `{transition}` whose target state is missing from the state list"
+            ),
+            Self::DuplicateTargetState {
+                machine,
+                transition,
+                state,
+            } => write!(
+                formatter,
+                "machine graph `{machine}` contains transition `{transition}` with duplicate target state `{state}`"
             ),
         }
     }
@@ -187,9 +213,9 @@ where
     S: Copy + Eq + std::hash::Hash + 'static,
     T: Copy + Eq + 'static,
 {
-    let mut state_ids = HashSet::with_capacity(graph.states.len());
+    let mut state_names = HashMap::with_capacity(graph.states.len());
     for state in graph.states.iter() {
-        if !state_ids.insert(state.id) {
+        if state_names.insert(state.id, state.rust_name).is_some() {
             return Err(MachineDocError::DuplicateStateId {
                 machine: graph.machine.rust_type_path,
                 state: state.rust_name,
@@ -197,24 +223,39 @@ where
         }
     }
 
+    let mut transition_ids = Vec::with_capacity(graph.transitions.len());
     for transition in graph.transitions.iter() {
-        if !state_ids.contains(&transition.from) {
+        if transition_ids.contains(&transition.id) {
+            return Err(MachineDocError::DuplicateTransitionId {
+                machine: graph.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        }
+        transition_ids.push(transition.id);
+
+        if !state_names.contains_key(&transition.from) {
             return Err(MachineDocError::MissingSourceState {
                 machine: graph.machine.rust_type_path,
                 transition: transition.method_name,
             });
         }
 
-        if transition
-            .to
-            .iter()
-            .copied()
-            .any(|target| !state_ids.contains(&target))
-        {
-            return Err(MachineDocError::MissingTargetState {
-                machine: graph.machine.rust_type_path,
-                transition: transition.method_name,
-            });
+        let mut seen_targets = HashSet::with_capacity(transition.to.len());
+        for target in transition.to.iter().copied() {
+            let Some(state_name) = state_names.get(&target).copied() else {
+                return Err(MachineDocError::MissingTargetState {
+                    machine: graph.machine.rust_type_path,
+                    transition: transition.method_name,
+                });
+            };
+
+            if !seen_targets.insert(target) {
+                return Err(MachineDocError::DuplicateTargetState {
+                    machine: graph.machine.rust_type_path,
+                    transition: transition.method_name,
+                    state: state_name,
+                });
+            }
         }
     }
 

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -37,7 +37,7 @@ where
             let to = node_id(state_positions[target]);
             lines.push(format!(
                 "    {from} -->|{}| {to}",
-                escape_label(edge.descriptor.method_name)
+                escape_edge_label(edge.descriptor.method_name)
             ));
         }
     }
@@ -62,4 +62,15 @@ fn escape_label(label: &str) -> String {
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\n")
+}
+
+fn escape_edge_label(label: &str) -> String {
+    label
+        .replace('&', "&amp;")
+        .replace('|', "&#124;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace('\n', "<br/>")
 }

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use crate::MachineDoc;
+
+/// Renders a machine-local topology as a Mermaid flow graph.
+pub fn mermaid<S, T>(doc: &MachineDoc<S, T>) -> String
+where
+    S: Copy + Eq + std::hash::Hash + 'static,
+    T: 'static,
+{
+    let state_positions: HashMap<S, usize> = doc
+        .states
+        .iter()
+        .enumerate()
+        .map(|(index, state)| (state.descriptor.id, index))
+        .collect();
+
+    let mut lines = vec!["graph TD".to_string()];
+    for (index, state) in doc.states.iter().enumerate() {
+        lines.push(format!(
+            "    {}[\"{}\"]",
+            node_id(index),
+            escape_label(&state_label(
+                state.descriptor.rust_name,
+                state.descriptor.has_data
+            ))
+        ));
+    }
+
+    if !doc.edges.is_empty() {
+        lines.push(String::new());
+    }
+
+    for edge in &doc.edges {
+        let from = node_id(state_positions[&edge.descriptor.from]);
+        for target in edge.descriptor.to.iter().copied() {
+            let to = node_id(state_positions[&target]);
+            lines.push(format!(
+                "    {from} -->|{}| {to}",
+                escape_label(edge.descriptor.method_name)
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn node_id(index: usize) -> String {
+    format!("s{index}")
+}
+
+fn state_label(rust_name: &str, has_data: bool) -> String {
+    if has_data {
+        format!("{rust_name} (data)")
+    } else {
+        rust_name.to_string()
+    }
+}
+
+fn escape_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -33,8 +33,8 @@ where
 
     for edge in &doc.edges {
         let from = node_id(state_positions[&edge.descriptor.from]);
-        for target in edge.descriptor.to.iter().copied() {
-            let to = node_id(state_positions[&target]);
+        for target in edge.descriptor.to {
+            let to = node_id(state_positions[target]);
             lines.push(format!(
                 "    {from} -->|{}| {to}",
                 escape_label(edge.descriptor.method_name)

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -9,14 +9,14 @@ where
     T: 'static,
 {
     let state_positions: HashMap<S, usize> = doc
-        .states
+        .states()
         .iter()
         .enumerate()
         .map(|(index, state)| (state.descriptor.id, index))
         .collect();
 
     let mut lines = vec!["graph TD".to_string()];
-    for (index, state) in doc.states.iter().enumerate() {
+    for (index, state) in doc.states().iter().enumerate() {
         lines.push(format!(
             "    {}[\"{}\"]",
             node_id(index),
@@ -27,11 +27,11 @@ where
         ));
     }
 
-    if !doc.edges.is_empty() {
+    if !doc.edges().is_empty() {
         lines.push(String::new());
     }
 
-    for edge in &doc.edges {
+    for edge in doc.edges() {
         let from = node_id(state_positions[&edge.descriptor.from]);
         for target in edge.descriptor.to {
             let to = node_id(state_positions[target]);

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -320,6 +320,19 @@ static VALID_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
     },
 ];
 
+static DUPLICATE_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
+    StateDescriptor {
+        id: InvalidStateId::Draft,
+        rust_name: "Draft",
+        has_data: false,
+    },
+    StateDescriptor {
+        id: InvalidStateId::Draft,
+        rust_name: "DraftDuplicate",
+        has_data: false,
+    },
+];
+
 static INVALID_TARGETS: [InvalidStateId; 1] = [InvalidStateId::Missing];
 
 static INVALID_SOURCE_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
@@ -366,6 +379,15 @@ static INVALID_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> =
     transitions: TransitionInventory::new(invalid_target_transitions),
 };
 
+static DUPLICATE_STATE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::duplicate_state",
+        rust_type_path: "tests::duplicate_state::Flow",
+    },
+    states: &DUPLICATE_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(invalid_target_transitions),
+};
+
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
     assert_eq!(
@@ -384,6 +406,17 @@ fn rejects_external_graph_with_missing_transition_target() {
         Err(MachineDocError::MissingTargetState {
             machine: "tests::invalid_target::Flow",
             transition: "submit",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_duplicate_state_ids() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&DUPLICATE_STATE_GRAPH),
+        Err(MachineDocError::DuplicateStateId {
+            machine: "tests::duplicate_state::Flow",
+            state: "DraftDuplicate",
         })
     );
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
 use statum::{
     MachineDescriptor, MachineGraph, StateDescriptor, TransitionDescriptor, TransitionInventory,
 };
@@ -503,6 +506,37 @@ static DUPLICATE_TRANSITION_SITE_GRAPH: MachineGraph<InvalidStateId, InvalidTran
         transitions: TransitionInventory::new(duplicate_transition_site_transitions),
     };
 
+static FLAKY_INVENTORY_LOCK: Mutex<()> = Mutex::new(());
+static FLAKY_TRANSITION_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+static FLAKY_VALID_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
+    [TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit",
+        from: InvalidStateId::Draft,
+        to: &VALID_PUBLISHED_TARGET,
+    }];
+
+static EMPTY_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 0] = [];
+
+fn flaky_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    let call = FLAKY_TRANSITION_CALLS.fetch_add(1, Ordering::SeqCst);
+    if call.is_multiple_of(2) {
+        &FLAKY_VALID_TRANSITIONS
+    } else {
+        &EMPTY_TRANSITIONS
+    }
+}
+
+static FLAKY_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::flaky_inventory",
+        rust_type_path: "tests::flaky_inventory::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(flaky_transitions),
+};
+
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
     assert_eq!(
@@ -577,5 +611,28 @@ fn rejects_external_graph_with_duplicate_transition_sites() {
             state: "Draft",
             transition: "review",
         })
+    );
+}
+
+#[test]
+fn snapshots_external_transition_inventory_once_per_export() {
+    let _guard = FLAKY_INVENTORY_LOCK.lock().expect("flaky inventory lock");
+    FLAKY_TRANSITION_CALLS.store(0, Ordering::SeqCst);
+
+    let doc = MachineDoc::try_from_graph(&FLAKY_GRAPH)
+        .expect("flaky inventory should still export from one consistent snapshot");
+
+    assert_eq!(
+        doc.roots()
+            .map(|state| state.descriptor.rust_name)
+            .collect::<Vec<_>>(),
+        vec!["Draft"]
+    );
+    assert_eq!(
+        doc.edges()
+            .iter()
+            .map(|edge| edge.descriptor.method_name)
+            .collect::<Vec<_>>(),
+        vec!["submit"]
     );
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -306,6 +306,7 @@ enum InvalidStateId {
 enum InvalidTransitionId {
     Submit,
     Publish,
+    Archive,
 }
 
 static VALID_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
@@ -389,6 +390,24 @@ static DUPLICATE_TARGET_TRANSITIONS: [TransitionDescriptor<InvalidStateId, Inval
     to: &DUPLICATE_PUBLISHED_TARGETS,
 }];
 
+static DUPLICATE_TRANSITION_SITE_TRANSITIONS: [TransitionDescriptor<
+    InvalidStateId,
+    InvalidTransitionId,
+>; 2] = [
+    TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "review",
+        from: InvalidStateId::Draft,
+        to: &VALID_PUBLISHED_TARGET,
+    },
+    TransitionDescriptor {
+        id: InvalidTransitionId::Archive,
+        method_name: "review",
+        from: InvalidStateId::Draft,
+        to: &VALID_PUBLISHED_TARGET,
+    },
+];
+
 fn invalid_source_transitions(
 ) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     &INVALID_SOURCE_TRANSITIONS
@@ -412,6 +431,11 @@ fn duplicate_transition_id_transitions(
 fn duplicate_target_transitions(
 ) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     &DUPLICATE_TARGET_TRANSITIONS
+}
+
+fn duplicate_transition_site_transitions(
+) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &DUPLICATE_TRANSITION_SITE_TRANSITIONS
 }
 
 static INVALID_SOURCE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
@@ -468,6 +492,16 @@ static DUPLICATE_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId>
     states: &VALID_STATE_DESCRIPTORS,
     transitions: TransitionInventory::new(duplicate_target_transitions),
 };
+
+static DUPLICATE_TRANSITION_SITE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> =
+    MachineGraph {
+        machine: MachineDescriptor {
+            module_path: "tests::duplicate_transition_site",
+            rust_type_path: "tests::duplicate_transition_site::Flow",
+        },
+        states: &VALID_STATE_DESCRIPTORS,
+        transitions: TransitionInventory::new(duplicate_transition_site_transitions),
+    };
 
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
@@ -530,6 +564,18 @@ fn rejects_external_graph_with_duplicate_target_states() {
             machine: "tests::duplicate_target::Flow",
             transition: "branch",
             state: "Published",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_duplicate_transition_sites() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&DUPLICATE_TRANSITION_SITE_GRAPH),
+        Err(MachineDocError::DuplicateTransitionSite {
+            machine: "tests::duplicate_transition_site::Flow",
+            state: "Draft",
+            transition: "review",
         })
     );
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -325,6 +325,9 @@ static VALID_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
     },
 ];
 
+static EMPTY_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 0] = [];
+static EMPTY_TARGET_IDS: [InvalidStateId; 0] = [];
+
 static DUPLICATE_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
     StateDescriptor {
         id: InvalidStateId::Draft,
@@ -518,6 +521,13 @@ static FLAKY_VALID_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTra
     }];
 
 static EMPTY_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 0] = [];
+static EMPTY_TARGET_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
+    [TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit",
+        from: InvalidStateId::Draft,
+        to: &EMPTY_TARGET_IDS,
+    }];
 
 fn flaky_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     let call = FLAKY_TRANSITION_CALLS.fetch_add(1, Ordering::SeqCst);
@@ -526,6 +536,11 @@ fn flaky_transitions() -> &'static [TransitionDescriptor<InvalidStateId, Invalid
     } else {
         &EMPTY_TRANSITIONS
     }
+}
+
+fn empty_target_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>]
+{
+    &EMPTY_TARGET_TRANSITIONS
 }
 
 static FLAKY_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
@@ -537,6 +552,24 @@ static FLAKY_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineG
     transitions: TransitionInventory::new(flaky_transitions),
 };
 
+static EMPTY_STATE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::empty_state_list",
+        rust_type_path: "tests::empty_state_list::Flow",
+    },
+    states: &EMPTY_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(|| &EMPTY_TRANSITIONS),
+};
+
+static EMPTY_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::empty_target_set",
+        rust_type_path: "tests::empty_target_set::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(empty_target_transitions),
+};
+
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
     assert_eq!(
@@ -544,6 +577,16 @@ fn rejects_external_graph_with_missing_transition_source() {
         Err(MachineDocError::MissingSourceState {
             machine: "tests::invalid_source::Flow",
             transition: "submit",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_empty_state_list() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&EMPTY_STATE_GRAPH),
+        Err(MachineDocError::EmptyStateList {
+            machine: "tests::empty_state_list::Flow",
         })
     );
 }
@@ -566,6 +609,17 @@ fn rejects_external_graph_with_duplicate_state_ids() {
         Err(MachineDocError::DuplicateStateId {
             machine: "tests::duplicate_state::Flow",
             state: "DraftDuplicate",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_empty_target_set() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&EMPTY_TARGET_GRAPH),
+        Err(MachineDocError::EmptyTargetSet {
+            machine: "tests::empty_target_set::Flow",
+            transition: "submit",
         })
     );
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 
-use statum_graph::{render, MachineDoc};
+use statum::{
+    MachineDescriptor, MachineGraph, StateDescriptor, TransitionDescriptor, TransitionInventory,
+};
+use statum_graph::{render, MachineDoc, MachineDocError};
 
 mod linear {
     use statum::{machine, state, transition};
@@ -188,9 +191,9 @@ mod macro_generated {
 fn exports_linear_machine_topology_from_graph() {
     let doc = MachineDoc::from_machine::<linear::Flow<linear::Draft>>();
 
-    assert_eq!(doc.machine.rust_type_path, "export::linear::Flow");
+    assert_eq!(doc.machine().rust_type_path, "export::linear::Flow");
     assert_eq!(
-        doc.states
+        doc.states()
             .iter()
             .map(|state| (
                 state.descriptor.rust_name,
@@ -205,7 +208,7 @@ fn exports_linear_machine_topology_from_graph() {
         ]
     );
     assert_eq!(
-        doc.edges
+        doc.edges()
             .iter()
             .map(|edge| edge.descriptor.method_name)
             .collect::<Vec<_>>(),
@@ -218,7 +221,7 @@ fn preserves_exact_branch_targets_and_sorts_edges_stably() {
     let doc = MachineDoc::from_machine::<branching::Flow<branching::Review>>();
 
     assert_eq!(
-        doc.edges
+        doc.edges()
             .iter()
             .map(|edge| edge.descriptor.method_name)
             .collect::<Vec<_>>(),
@@ -233,7 +236,7 @@ fn preserves_exact_branch_targets_and_sorts_edges_stably() {
     );
 
     let maybe_decide = doc
-        .edges
+        .edges()
         .iter()
         .find(|edge| edge.descriptor.method_name == "maybe_decide")
         .expect("branching transition");
@@ -284,10 +287,103 @@ fn exports_macro_generated_transition_sites() {
     let doc = MachineDoc::from_machine::<macro_generated::Flow<macro_generated::Enabled>>();
 
     assert_eq!(
-        doc.edges
+        doc.edges()
             .iter()
             .map(|edge| edge.descriptor.method_name)
             .collect::<Vec<_>>(),
         vec!["enable", "via_macro"]
+    );
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+enum InvalidStateId {
+    Draft,
+    Published,
+    Missing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+enum InvalidTransitionId {
+    Submit,
+}
+
+static VALID_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
+    StateDescriptor {
+        id: InvalidStateId::Draft,
+        rust_name: "Draft",
+        has_data: false,
+    },
+    StateDescriptor {
+        id: InvalidStateId::Published,
+        rust_name: "Published",
+        has_data: false,
+    },
+];
+
+static INVALID_TARGETS: [InvalidStateId; 1] = [InvalidStateId::Missing];
+
+static INVALID_SOURCE_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
+    [TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit",
+        from: InvalidStateId::Missing,
+        to: &INVALID_TARGETS,
+    }];
+
+static INVALID_TARGET_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
+    [TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit",
+        from: InvalidStateId::Draft,
+        to: &INVALID_TARGETS,
+    }];
+
+fn invalid_source_transitions(
+) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &INVALID_SOURCE_TRANSITIONS
+}
+
+fn invalid_target_transitions(
+) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &INVALID_TARGET_TRANSITIONS
+}
+
+static INVALID_SOURCE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::invalid_source",
+        rust_type_path: "tests::invalid_source::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(invalid_source_transitions),
+};
+
+static INVALID_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::invalid_target",
+        rust_type_path: "tests::invalid_target::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(invalid_target_transitions),
+};
+
+#[test]
+fn rejects_external_graph_with_missing_transition_source() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&INVALID_SOURCE_GRAPH),
+        Err(MachineDocError::MissingSourceState {
+            machine: "tests::invalid_source::Flow",
+            transition: "submit",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_missing_transition_target() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&INVALID_TARGET_GRAPH),
+        Err(MachineDocError::MissingTargetState {
+            machine: "tests::invalid_target::Flow",
+            transition: "submit",
+        })
     );
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -1,0 +1,293 @@
+#![allow(dead_code)]
+
+use statum_graph::{render, MachineDoc};
+
+mod linear {
+    use statum::{machine, state, transition};
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct ReviewPayload {
+        pub reviewer: &'static str,
+    }
+
+    #[state]
+    pub enum State {
+        Draft,
+        Review(ReviewPayload),
+        Published,
+    }
+
+    #[machine]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<Draft> {
+        fn submit(self) -> Flow<Review> {
+            self.transition_with(ReviewPayload { reviewer: "amy" })
+        }
+    }
+
+    #[transition]
+    impl Flow<Review> {
+        fn publish(self) -> Flow<Published> {
+            self.transition()
+        }
+    }
+}
+
+mod branching {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Draft,
+        Review,
+        Accepted,
+        Rejected,
+        Archived,
+    }
+
+    #[machine]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<Draft> {
+        fn submit(self) -> Flow<Review> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Review> {
+        fn maybe_decide(
+            self,
+            accept: bool,
+        ) -> ::core::result::Result<Flow<Accepted>, Flow<Rejected>> {
+            if accept {
+                Ok(self.accept())
+            } else {
+                Err(self.reject())
+            }
+        }
+
+        fn accept(self) -> Flow<Accepted> {
+            self.transition()
+        }
+
+        fn reject(self) -> Flow<Rejected> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Accepted> {
+        fn archive(self) -> Flow<Archived> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Rejected> {
+        fn archive(self) -> Flow<Archived> {
+            self.transition()
+        }
+    }
+}
+
+mod multi_root {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        First,
+        Second,
+        Finished,
+    }
+
+    #[machine]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<First> {
+        fn finish(self) -> Flow<Finished> {
+            self.transition()
+        }
+    }
+}
+
+mod no_root {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Draft,
+        Review,
+        Rejected,
+    }
+
+    #[machine]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<Draft> {
+        fn submit(self) -> Flow<Review> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Review> {
+        fn reject(self) -> Flow<Rejected> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Rejected> {
+        fn rework(self) -> Flow<Draft> {
+            self.transition()
+        }
+    }
+}
+
+mod macro_generated {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Start,
+        Enabled,
+        MacroTarget,
+    }
+
+    #[machine]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<Start> {
+        fn enable(self) -> Flow<Enabled> {
+            self.transition()
+        }
+    }
+
+    macro_rules! generated_transitions {
+        () => {
+            #[transition]
+            impl Flow<Enabled> {
+                fn via_macro(self) -> Flow<MacroTarget> {
+                    self.transition()
+                }
+            }
+        };
+    }
+
+    generated_transitions!();
+}
+
+#[test]
+fn exports_linear_machine_topology_from_graph() {
+    let doc = MachineDoc::from_machine::<linear::Flow<linear::Draft>>();
+
+    assert_eq!(doc.machine.rust_type_path, "export::linear::Flow");
+    assert_eq!(
+        doc.states
+            .iter()
+            .map(|state| (
+                state.descriptor.rust_name,
+                state.descriptor.has_data,
+                state.is_root
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            ("Draft", false, true),
+            ("Review", true, false),
+            ("Published", false, false),
+        ]
+    );
+    assert_eq!(
+        doc.edges
+            .iter()
+            .map(|edge| edge.descriptor.method_name)
+            .collect::<Vec<_>>(),
+        vec!["submit", "publish"]
+    );
+}
+
+#[test]
+fn preserves_exact_branch_targets_and_sorts_edges_stably() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Review>>();
+
+    assert_eq!(
+        doc.edges
+            .iter()
+            .map(|edge| edge.descriptor.method_name)
+            .collect::<Vec<_>>(),
+        vec![
+            "submit",
+            "accept",
+            "maybe_decide",
+            "reject",
+            "archive",
+            "archive"
+        ]
+    );
+
+    let maybe_decide = doc
+        .edges
+        .iter()
+        .find(|edge| edge.descriptor.method_name == "maybe_decide")
+        .expect("branching transition");
+    assert_eq!(
+        maybe_decide
+            .descriptor
+            .to
+            .iter()
+            .map(|state| doc.state(*state).unwrap().descriptor.rust_name)
+            .collect::<Vec<_>>(),
+        vec!["Accepted", "Rejected"]
+    );
+}
+
+#[test]
+fn derives_multiple_roots_and_zero_roots_from_topology() {
+    let multi_root = MachineDoc::from_machine::<multi_root::Flow<multi_root::First>>();
+    assert_eq!(
+        multi_root
+            .roots()
+            .map(|state| state.descriptor.rust_name)
+            .collect::<Vec<_>>(),
+        vec!["First", "Second"]
+    );
+
+    let no_root = MachineDoc::from_machine::<no_root::Flow<no_root::Draft>>();
+    assert_eq!(no_root.roots().count(), 0);
+}
+
+#[test]
+fn mermaid_snapshot_is_stable_for_reconverging_graphs() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    insta::assert_snapshot!("branching_flow_mermaid", render::mermaid(&doc));
+}
+
+#[test]
+fn mermaid_renders_one_edge_per_legal_target() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    let mermaid = render::mermaid(&doc);
+
+    assert_eq!(mermaid.matches("-->|maybe_decide|").count(), 2);
+    assert!(mermaid.contains("s1 -->|maybe_decide| s2"));
+    assert!(mermaid.contains("s1 -->|maybe_decide| s3"));
+}
+
+#[test]
+fn exports_macro_generated_transition_sites() {
+    let doc = MachineDoc::from_machine::<macro_generated::Flow<macro_generated::Enabled>>();
+
+    assert_eq!(
+        doc.edges
+            .iter()
+            .map(|edge| edge.descriptor.method_name)
+            .collect::<Vec<_>>(),
+        vec!["enable", "via_macro"]
+    );
+}

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -334,6 +334,7 @@ static DUPLICATE_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
 ];
 
 static INVALID_TARGETS: [InvalidStateId; 1] = [InvalidStateId::Missing];
+static VALID_PUBLISHED_TARGET: [InvalidStateId; 1] = [InvalidStateId::Published];
 
 static INVALID_SOURCE_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
     [TransitionDescriptor {
@@ -351,6 +352,14 @@ static INVALID_TARGET_TRANSITIONS: [TransitionDescriptor<InvalidStateId, Invalid
         to: &INVALID_TARGETS,
     }];
 
+static PIPE_LABEL_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
+    [TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit|review",
+        from: InvalidStateId::Draft,
+        to: &VALID_PUBLISHED_TARGET,
+    }];
+
 fn invalid_source_transitions(
 ) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     &INVALID_SOURCE_TRANSITIONS
@@ -359,6 +368,11 @@ fn invalid_source_transitions(
 fn invalid_target_transitions(
 ) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     &INVALID_TARGET_TRANSITIONS
+}
+
+fn pipe_label_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>]
+{
+    &PIPE_LABEL_TRANSITIONS
 }
 
 static INVALID_SOURCE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
@@ -386,6 +400,15 @@ static DUPLICATE_STATE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> 
     },
     states: &DUPLICATE_STATE_DESCRIPTORS,
     transitions: TransitionInventory::new(invalid_target_transitions),
+};
+
+static PIPE_LABEL_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::pipe_label",
+        rust_type_path: "tests::pipe_label::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(pipe_label_transitions),
 };
 
 #[test]
@@ -419,4 +442,13 @@ fn rejects_external_graph_with_duplicate_state_ids() {
             state: "DraftDuplicate",
         })
     );
+}
+
+#[test]
+fn mermaid_escapes_external_edge_labels() {
+    let doc = MachineDoc::try_from_graph(&PIPE_LABEL_GRAPH)
+        .expect("external graph with valid topology should export");
+    let mermaid = render::mermaid(&doc);
+
+    assert!(mermaid.contains("-->|submit&#124;review|"));
 }

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -305,6 +305,7 @@ enum InvalidStateId {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 enum InvalidTransitionId {
     Submit,
+    Publish,
 }
 
 static VALID_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
@@ -335,6 +336,8 @@ static DUPLICATE_STATE_DESCRIPTORS: [StateDescriptor<InvalidStateId>; 2] = [
 
 static INVALID_TARGETS: [InvalidStateId; 1] = [InvalidStateId::Missing];
 static VALID_PUBLISHED_TARGET: [InvalidStateId; 1] = [InvalidStateId::Published];
+static DUPLICATE_PUBLISHED_TARGETS: [InvalidStateId; 2] =
+    [InvalidStateId::Published, InvalidStateId::Published];
 
 static INVALID_SOURCE_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>; 1] =
     [TransitionDescriptor {
@@ -360,6 +363,32 @@ static PIPE_LABEL_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTran
         to: &VALID_PUBLISHED_TARGET,
     }];
 
+static DUPLICATE_TRANSITION_ID_TRANSITIONS: [TransitionDescriptor<
+    InvalidStateId,
+    InvalidTransitionId,
+>; 2] = [
+    TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "submit",
+        from: InvalidStateId::Draft,
+        to: &VALID_PUBLISHED_TARGET,
+    },
+    TransitionDescriptor {
+        id: InvalidTransitionId::Submit,
+        method_name: "publish",
+        from: InvalidStateId::Published,
+        to: &VALID_PUBLISHED_TARGET,
+    },
+];
+
+static DUPLICATE_TARGET_TRANSITIONS: [TransitionDescriptor<InvalidStateId, InvalidTransitionId>;
+    1] = [TransitionDescriptor {
+    id: InvalidTransitionId::Publish,
+    method_name: "branch",
+    from: InvalidStateId::Draft,
+    to: &DUPLICATE_PUBLISHED_TARGETS,
+}];
+
 fn invalid_source_transitions(
 ) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
     &INVALID_SOURCE_TRANSITIONS
@@ -373,6 +402,16 @@ fn invalid_target_transitions(
 fn pipe_label_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>]
 {
     &PIPE_LABEL_TRANSITIONS
+}
+
+fn duplicate_transition_id_transitions(
+) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &DUPLICATE_TRANSITION_ID_TRANSITIONS
+}
+
+fn duplicate_target_transitions(
+) -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &DUPLICATE_TARGET_TRANSITIONS
 }
 
 static INVALID_SOURCE_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
@@ -409,6 +448,25 @@ static PIPE_LABEL_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = Mac
     },
     states: &VALID_STATE_DESCRIPTORS,
     transitions: TransitionInventory::new(pipe_label_transitions),
+};
+
+static DUPLICATE_TRANSITION_ID_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> =
+    MachineGraph {
+        machine: MachineDescriptor {
+            module_path: "tests::duplicate_transition_id",
+            rust_type_path: "tests::duplicate_transition_id::Flow",
+        },
+        states: &VALID_STATE_DESCRIPTORS,
+        transitions: TransitionInventory::new(duplicate_transition_id_transitions),
+    };
+
+static DUPLICATE_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::duplicate_target",
+        rust_type_path: "tests::duplicate_target::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(duplicate_target_transitions),
 };
 
 #[test]
@@ -451,4 +509,27 @@ fn mermaid_escapes_external_edge_labels() {
     let mermaid = render::mermaid(&doc);
 
     assert!(mermaid.contains("-->|submit&#124;review|"));
+}
+
+#[test]
+fn rejects_external_graph_with_duplicate_transition_ids() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&DUPLICATE_TRANSITION_ID_GRAPH),
+        Err(MachineDocError::DuplicateTransitionId {
+            machine: "tests::duplicate_transition_id::Flow",
+            transition: "publish",
+        })
+    );
+}
+
+#[test]
+fn rejects_external_graph_with_duplicate_target_states() {
+    assert_eq!(
+        MachineDoc::try_from_graph(&DUPLICATE_TARGET_GRAPH),
+        Err(MachineDocError::DuplicateTargetState {
+            machine: "tests::duplicate_target::Flow",
+            transition: "branch",
+            state: "Published",
+        })
+    );
 }

--- a/statum-graph/tests/snapshots/export__branching_flow_mermaid.snap
+++ b/statum-graph/tests/snapshots/export__branching_flow_mermaid.snap
@@ -1,0 +1,18 @@
+---
+source: statum-graph/tests/export.rs
+expression: render::mermaid(&doc)
+---
+graph TD
+    s0["Draft"]
+    s1["Review"]
+    s2["Accepted"]
+    s3["Rejected"]
+    s4["Archived"]
+
+    s0 -->|submit| s1
+    s1 -->|accept| s2
+    s1 -->|maybe_decide| s2
+    s1 -->|maybe_decide| s3
+    s1 -->|reject| s3
+    s2 -->|archive| s4
+    s3 -->|archive| s4

--- a/statum/README.md
+++ b/statum/README.md
@@ -70,6 +70,8 @@ impl Light<On> {
   CLI explainers, graph exports, generated docs, branch-strip views, or runtime
   replay/debug tooling. Statum exposes exact transition sites instead of a
   coarse machine-wide state list.
+- `statum-graph` is the companion crate for exporting that static graph surface
+  as machine-local topology and Mermaid output.
 - API docs: <https://docs.rs/statum>
 - Repository README: <https://github.com/eboody/statum/blob/main/README.md>
 - Coding-agent kit: <https://github.com/eboody/statum/blob/main/docs/agents/README.md>


### PR DESCRIPTION
## Summary

Add a new `statum-graph` crate that exports machine-local topology from `statum::MachineIntrospection::GRAPH` and renders it as Mermaid.

This includes:
- a `MachineDoc` export surface for machine, state, edge, and root metadata
- a Mermaid renderer for exported machine-local topology
- tests for linear flows, exact branch targets, multiple roots, zero-root cycles, and macro-generated transitions
- workspace and docs updates for the new crate

## Authority boundary

Claimed authority surface:
- machine identity
- states
- transition sites
- exact legal targets
- roots derivable from the static graph itself

Actual observation point:
- the static `MachineIntrospection::GRAPH` value emitted by Statum introspection

Unsupported / intentionally out of scope:
- runtime-selected branch choice for one execution
- orchestration order across machines
- consumer-owned explanation or presentation metadata

Adversarial coverage in this PR:
- macro-generated transition sites in `statum-graph/tests/export.rs`

## Verification

- `cargo test -p statum-graph --offline`
- `cargo clippy -p statum-graph --offline --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p statum-graph --offline --no-deps`
- `cargo test --workspace --offline`
- `cargo clippy --workspace --offline --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --offline --no-deps`
