### PR TITLE
docs(graph): expand statum-graph usage guide

### DIFF
--- a/statum-graph/README.md
+++ b/statum-graph/README.md
@@ -74,3 +74,115 @@ let mermaid = render::mermaid(&doc);
 assert!(mermaid.contains("s1 -->|decide| s2"));
 assert!(mermaid.contains("s1 -->|decide| s3"));
 ```
+
+## Mermaid Output
+
+The renderer returns ordinary Mermaid flowchart text:
+
+```text
+graph TD
+    s0["Draft"]
+    s1["Review"]
+    s2["Accepted"]
+    s3["Rejected"]
+
+    s0 -->|submit| s1
+    s1 -->|accept| s2
+    s1 -->|decide| s2
+    s1 -->|decide| s3
+    s1 -->|reject| s3
+```
+
+The output is deterministic for one validated `MachineDoc`, so it works well
+for snapshot tests, generated docs, and CLI output.
+
+## Traversing A Graph
+
+`MachineDoc` gives you the machine descriptor, the state list, the transition
+sites, and the root states:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::MachineDoc;
+# #[state]
+# enum FlowState {
+#     Draft,
+#     Review,
+#     Accepted,
+#     Rejected,
+# }
+# #[machine]
+# struct Flow<FlowState> {}
+# #[transition]
+# impl Flow<Draft> {
+#     fn submit(self) -> Flow<Review> {
+#         self.transition()
+#     }
+# }
+# #[transition]
+# impl Flow<Review> {
+#     fn accept(self) -> Flow<Accepted> {
+#         self.transition()
+#     }
+#     fn reject(self) -> Flow<Rejected> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+
+assert!(doc.machine().rust_type_path.ends_with("Flow"));
+assert_eq!(
+    doc.roots()
+        .map(|state| state.descriptor.rust_name)
+        .collect::<Vec<_>>(),
+    vec!["Draft"]
+);
+assert_eq!(
+    doc.states()
+        .iter()
+        .map(|state| state.descriptor.rust_name)
+        .collect::<Vec<_>>(),
+    vec!["Draft", "Review", "Accepted", "Rejected"]
+);
+assert_eq!(
+    doc.edges()
+        .iter()
+        .map(|edge| edge.descriptor.method_name)
+        .collect::<Vec<_>>(),
+    vec!["submit", "accept", "reject"]
+);
+```
+
+Use `doc.state(id)` when you need to map a transition target id back to the
+exported state descriptor.
+
+## Choosing An Entry Point
+
+Use `MachineDoc::from_machine::<M>()` when the graph comes from a real Statum
+machine type. That is the normal entry point for application code, test
+assertions, and generated documentation.
+
+Use `MachineDoc::try_from_graph(...)` when you already have a
+`statum::MachineGraph` and want `statum-graph` to validate it before rendering
+or traversal. This is mainly for external graph producers, tests, and tooling
+adapters.
+
+`try_from_graph(...)` rejects malformed graphs instead of guessing:
+
+- empty state lists
+- duplicate state ids
+- duplicate transition ids
+- duplicate transition sites for one `(source state, method name)` pair
+- missing source states
+- missing target states
+- empty target sets
+- duplicate target states within one transition
+
+The error surface is `MachineDocError`.
+
+## Scope
+
+`statum-graph` exports static machine-local topology. It does not tell you
+which branch ran in one execution, how multiple machines were orchestrated at
+runtime, or how machine data changed over time. For those use cases, pair the
+static graph with explicit runtime events or snapshots from the application.

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -4,8 +4,13 @@
 //! machine identity, states, transition sites, exact legal targets, and
 //! roots derivable from the static graph itself.
 //!
-//! It does not model orchestration order across machines, runtime-selected
-//! branches for one run, or any consumer-owned presentation metadata.
+//! Use [`MachineDoc::from_machine`] for Statum-generated machine families and
+//! [`MachineDoc::try_from_graph`] when you need to validate an externally
+//! supplied [`MachineGraph`] before rendering or traversal.
+//!
+//! This crate does not model orchestration order across machines,
+//! runtime-selected branches for one run, or any consumer-owned presentation
+//! metadata.
 
 use std::collections::{HashMap, HashSet};
 
@@ -184,6 +189,10 @@ where
     T: Copy + Eq + 'static,
 {
     /// Exports one machine family from a concrete `MachineIntrospection` type.
+    ///
+    /// This is the normal entry point when the graph comes from Statum itself.
+    /// It will panic only if Statum emitted an invalid
+    /// `MachineIntrospection::GRAPH`.
     pub fn from_machine<M>() -> Self
     where
         M: MachineIntrospection<StateId = S, TransitionId = T>,
@@ -193,6 +202,10 @@ where
     }
 
     /// Exports one externally supplied machine graph after validating it.
+    ///
+    /// Use this when the graph does not come from a concrete Statum machine
+    /// type and you want malformed external graphs to fail closed with
+    /// [`MachineDocError`] instead of being rendered best-effort.
     pub fn try_from_graph(graph: &'static MachineGraph<S, T>) -> Result<Self, MachineDocError> {
         let transitions = graph.transitions.as_slice();
         validate_graph(graph.machine, graph.states, transitions)?;

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -2,7 +2,11 @@ use std::collections::HashMap;
 
 use crate::MachineDoc;
 
-/// Renders a machine-local topology as a Mermaid flow graph.
+/// Renders a validated machine-local topology as Mermaid flowchart text.
+///
+/// Output ordering is deterministic for one [`MachineDoc`]. State labels and
+/// edge labels are escaped for Mermaid so the returned string is suitable for
+/// snapshot tests, generated docs, and CLI output.
 pub fn mermaid<S, T>(doc: &MachineDoc<S, T>) -> String
 where
     S: Copy + Eq + std::hash::Hash + 'static,


### PR DESCRIPTION
## Summary
- expand the `statum-graph` README with Mermaid output, graph traversal, entry-point guidance, and scope notes
- document when to use `MachineDoc::from_machine(...)` versus `MachineDoc::try_from_graph(...)`
- clarify Mermaid renderer guarantees in the Rust docs

## Verification
- `cargo test -p statum-graph --offline`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p statum-graph --offline --no-deps`
