### PR TITLE
feat(graph): add codebase export CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
 
   msrv-1-93:
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.93.1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.93.1
@@ -75,6 +77,8 @@ jobs:
 
   security-deny:
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.93.1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.93.1
@@ -84,6 +88,8 @@ jobs:
 
   security-audit:
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.93.1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.93.1
@@ -94,6 +100,8 @@ jobs:
   publish-dry-run:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.93.1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.93.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@
 - Happy-path tests are not sufficient for authority features. Add adversarial cases for constructs that differ across observation stages, including `#[cfg]`, macro-generated items, `include!`, and duplicate-id pressure where relevant.
 - Closeout for authority features must state: claimed authority surface, actual observation point, unsupported cases rejected or still open, and adversarial tests added.
 
+## Bug Hunt Rule
+- Treat pre-validation helpers as boundary surfaces when they can observe malformed input before the intended validator. Common examples: sort comparators, sort-key builders, dedup keys, display helpers, and path builders.
+- For APIs that promise writes under a directory but accept a file name or stem, reject separators, `..`, and absolute paths before creating directories or writing files.
+- Add adversarial tests for one malformed reference that reaches sort or key extraction before validation and one path-like file stem or name for directory-anchored writers when those surfaces exist.
+
 ## Project Structure & Module Organization
 This is a Rust workspace with four crates:
 - `statum/` public API crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "cargo-statum-graph",
     "module_path_extractor",
     "macro_registry",
     "statum-core",
@@ -18,5 +19,5 @@ statum = { path = "statum" }
 
 [workspace.metadata.scripts]
 version-bump = "cargo script scripts/update_version.rs -- 1.0.0"
-publish = "cargo publish -p module_path_extractor && cargo publish -p macro_registry && cargo publish -p statum-core && cargo publish -p statum-macros && cargo publish -p statum && cargo publish -p statum-graph"
+publish = "cargo publish -p module_path_extractor && cargo publish -p macro_registry && cargo publish -p statum-core && cargo publish -p statum-macros && cargo publish -p statum && cargo publish -p statum-graph && cargo publish -p cargo-statum-graph"
 publish-dry-run = "bash scripts/check_publish_dry_run.sh"

--- a/cargo-statum-graph/Cargo.toml
+++ b/cargo-statum-graph/Cargo.toml
@@ -1,0 +1,28 @@
+[dependencies]
+cargo_metadata = "0.21"
+clap = { version = "4.5.39", features = ["derive"] }
+statum-graph = { path = "../statum-graph", version = "0.6.9" }
+tempfile = "3"
+
+[dev-dependencies]
+tempfile = "3"
+
+[package]
+authors = ["Eran Boodnero <eran@eran.codes>"]
+categories = ["development-tools", "command-line-utilities"]
+description = "Cargo subcommand for zero-touch Statum graph export"
+documentation = "https://docs.rs/cargo-statum-graph"
+edition = "2021"
+keywords = [
+    "cargo",
+    "graph",
+    "mermaid",
+    "workflow",
+    "state-machine",
+]
+license = "MIT"
+name = "cargo-statum-graph"
+readme = "README.md"
+repository = "https://github.com/eboody/statum"
+rust-version = "1.93"
+version = "0.6.9"

--- a/cargo-statum-graph/README.md
+++ b/cargo-statum-graph/README.md
@@ -1,0 +1,47 @@
+# cargo-statum-graph
+
+`cargo-statum-graph` is the zero-touch CLI for codebase-level Statum graph
+export.
+
+It builds a temporary runner internally, links the selected crate, and writes
+the combined static codebase graph as Mermaid, DOT, PlantUML, and JSON.
+
+## Install
+
+```text
+cargo install cargo-statum-graph
+```
+
+## Usage
+
+```text
+cargo statum-graph codebase \
+  /path/to/workspace
+```
+
+That writes:
+
+- `/path/to/workspace/codebase.mmd`
+- `/path/to/workspace/codebase.dot`
+- `/path/to/workspace/codebase.puml`
+- `/path/to/workspace/codebase.json`
+
+If you want a different output directory:
+
+```text
+cargo statum-graph codebase \
+  /path/to/workspace \
+  --out-dir /tmp/codebase-graph
+```
+
+If you want to narrow export to one library package inside a multi-package
+workspace:
+
+```text
+cargo statum-graph codebase \
+  /path/to/workspace \
+  --package app
+```
+
+For local development against an unreleased Statum checkout, add
+`--patch-statum-root /path/to/statum`.

--- a/cargo-statum-graph/README.md
+++ b/cargo-statum-graph/README.md
@@ -4,7 +4,8 @@
 export.
 
 It builds a temporary runner internally, links the selected crate, and writes
-the combined static codebase graph as Mermaid, DOT, PlantUML, and JSON.
+the combined static codebase graph as Mermaid, DOT, PlantUML, and JSON,
+including declared validator-entry nodes from compiled `#[validators]` impls.
 
 ## Install
 

--- a/cargo-statum-graph/src/lib.rs
+++ b/cargo-statum-graph/src/lib.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::fmt;
+use std::fmt::Write as _;
 use std::fs;
 use std::io;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
@@ -34,6 +36,13 @@ pub enum Error {
     PackageHasNoLibrary {
         manifest_path: PathBuf,
         package: String,
+    },
+    InvalidStem {
+        stem: String,
+    },
+    NonUtf8Path {
+        role: &'static str,
+        path: PathBuf,
     },
     Io {
         action: &'static str,
@@ -89,6 +98,15 @@ impl fmt::Display for Error {
                 "package `{package}` from manifest `{}` does not expose a library target",
                 manifest_path.display()
             ),
+            Self::InvalidStem { stem } => write!(
+                formatter,
+                "invalid output stem `{stem}`: expected a simple file name without path separators"
+            ),
+            Self::NonUtf8Path { role, path } => write!(
+                formatter,
+                "cannot generate runner {role} from non-UTF-8 path `{}`",
+                path.display()
+            ),
             Self::Io {
                 action,
                 path,
@@ -127,12 +145,15 @@ impl std::error::Error for Error {
             Self::PackageNotFound { .. }
             | Self::AmbiguousPackage { .. }
             | Self::PackageHasNoLibrary { .. }
+            | Self::InvalidStem { .. }
+            | Self::NonUtf8Path { .. }
             | Self::RunnerFailed { .. } => None,
         }
     }
 }
 
 pub fn run(options: Options) -> Result<Vec<PathBuf>, Error> {
+    validate_output_stem(&options.stem)?;
     let input_path = absolutize(&options.input_path).map_err(Error::CurrentDir)?;
     let input = resolve_input(&input_path);
     let metadata = load_metadata(&input.manifest_path)?;
@@ -250,7 +271,7 @@ fn select_packages<'a>(
 }
 
 fn workspace_root_manifest(metadata: &Metadata) -> PathBuf {
-    metadata.workspace_root.as_std_path().join("Cargo.toml")
+    normalize_absolute_path(&metadata.workspace_root.as_std_path().join("Cargo.toml"))
 }
 
 fn workspace_packages<'a>(metadata: &'a Metadata, ids: &[PackageId]) -> Vec<&'a Package> {
@@ -333,7 +354,7 @@ fn write_runner_project(
     })?;
 
     let manifest_path = runner_dir.join("Cargo.toml");
-    let manifest = build_runner_manifest(selections, patch_root);
+    let manifest = build_runner_manifest(selections, patch_root)?;
     fs::write(&manifest_path, manifest).map_err(|source| Error::Io {
         action: "write generated runner manifest",
         path: manifest_path.clone(),
@@ -341,7 +362,7 @@ fn write_runner_project(
     })?;
 
     let main_path = src_dir.join("main.rs");
-    let main = build_runner_main(selections, out_dir, stem);
+    let main = build_runner_main(selections, out_dir, stem)?;
     fs::write(&main_path, main).map_err(|source| Error::Io {
         action: "write generated runner source",
         path: main_path.clone(),
@@ -351,7 +372,10 @@ fn write_runner_project(
     Ok(())
 }
 
-fn build_runner_manifest(selections: &[SelectedPackage<'_>], patch_root: Option<&Path>) -> String {
+fn build_runner_manifest(
+    selections: &[SelectedPackage<'_>],
+    patch_root: Option<&Path>,
+) -> Result<String, Error> {
     let mut manifest = String::from(
         "[package]\nname = \"statum-graph-runner\"\nversion = \"0.0.0\"\nedition = \"2021\"\npublish = false\n\n[dependencies]\n",
     );
@@ -366,8 +390,9 @@ fn build_runner_manifest(selections: &[SelectedPackage<'_>], patch_root: Option<
                     .manifest_path
                     .as_std_path()
                     .parent()
-                    .expect("package manifest should have a parent")
-            )
+                    .expect("package manifest should have a parent"),
+                "dependency package path",
+            )?,
         ));
     }
 
@@ -375,9 +400,9 @@ fn build_runner_manifest(selections: &[SelectedPackage<'_>], patch_root: Option<
         Some(root) => {
             manifest.push_str(&format!(
                 "statum-graph = {{ path = {} }}\n",
-                toml_path(root.join("statum-graph"))
+                toml_path(root.join("statum-graph"), "patched statum-graph path")?
             ));
-            push_patch_tables(&mut manifest, root);
+            push_patch_tables(&mut manifest, root)?;
         }
         None => {
             manifest.push_str(&format!(
@@ -387,10 +412,10 @@ fn build_runner_manifest(selections: &[SelectedPackage<'_>], patch_root: Option<
         }
     }
 
-    manifest
+    Ok(manifest)
 }
 
-fn push_patch_tables(manifest: &mut String, root: &Path) {
+fn push_patch_tables(manifest: &mut String, root: &Path) -> Result<(), Error> {
     for source in ["crates-io", "https://github.com/eboody/statum"] {
         if source == "crates-io" {
             manifest.push_str("\n[patch.crates-io]\n");
@@ -407,13 +432,19 @@ fn push_patch_tables(manifest: &mut String, root: &Path) {
         ] {
             manifest.push_str(&format!(
                 "{package} = {{ path = {} }}\n",
-                toml_path(root.join(package))
+                toml_path(root.join(package), "patched workspace package path")?
             ));
         }
     }
+
+    Ok(())
 }
 
-fn build_runner_main(selections: &[SelectedPackage<'_>], out_dir: &Path, stem: &str) -> String {
+fn build_runner_main(
+    selections: &[SelectedPackage<'_>],
+    out_dir: &Path,
+    stem: &str,
+) -> Result<String, Error> {
     let mut source = String::from("#[allow(unused_imports)]\n");
     for (index, selection) in selections.iter().enumerate() {
         source.push_str(&format!(
@@ -436,13 +467,13 @@ fn build_runner_main(selections: &[SelectedPackage<'_>], out_dir: &Path, stem: &
     source.push_str("        &doc,\n");
     source.push_str(&format!(
         "        {},\n",
-        rust_str(&out_dir.to_string_lossy())
+        rust_path(out_dir, "output directory")?
     ));
     source.push_str(&format!("        {},\n", rust_str(stem)));
     source.push_str("    )?;\n");
     source.push_str("    Ok(())\n");
     source.push_str("}\n");
-    source
+    Ok(source)
 }
 
 fn run_runner(runner_manifest_path: PathBuf, target_manifest_path: &Path) -> Result<(), Error> {
@@ -496,24 +527,96 @@ fn bundle_paths(out_dir: &Path, stem: &str) -> Vec<PathBuf> {
 }
 
 fn absolutize(path: &Path) -> io::Result<PathBuf> {
-    if path.is_absolute() {
-        Ok(path.to_path_buf())
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        Ok(env::current_dir()?.join(path))
-    }
+        env::current_dir()?.join(path)
+    };
+    Ok(normalize_absolute_path(&absolute))
 }
 
-fn toml_path(value: impl AsRef<Path>) -> String {
-    let value = value.as_ref().to_string_lossy();
-    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+fn rust_path(value: &Path, role: &'static str) -> Result<String, Error> {
+    Ok(rust_str(path_utf8(value, role)?))
+}
+
+fn toml_path(value: impl AsRef<Path>, role: &'static str) -> Result<String, Error> {
+    Ok(toml_str(path_utf8(value.as_ref(), role)?))
 }
 
 fn rust_str(value: &str) -> String {
-    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+    let escaped: String = value.chars().flat_map(char::escape_default).collect();
+    format!("\"{escaped}\"")
 }
 
 fn toml_str(value: &str) -> String {
-    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\t' => escaped.push_str("\\t"),
+            '\n' => escaped.push_str("\\n"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            '\r' => escaped.push_str("\\r"),
+            control if control.is_control() => {
+                let code = control as u32;
+                if code <= 0xFFFF {
+                    write!(&mut escaped, "\\u{code:04X}")
+                        .expect("writing to a String should not fail");
+                } else {
+                    write!(&mut escaped, "\\U{code:08X}")
+                        .expect("writing to a String should not fail");
+                }
+            }
+            other => escaped.push(other),
+        }
+    }
+
+    format!("\"{escaped}\"")
+}
+
+fn validate_output_stem(stem: &str) -> Result<(), Error> {
+    let mut components = Path::new(stem).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(Error::InvalidStem {
+            stem: stem.to_owned(),
+        }),
+    }
+}
+
+fn path_utf8<'a>(path: &'a Path, role: &'static str) -> Result<&'a str, Error> {
+    path.to_str().ok_or_else(|| Error::NonUtf8Path {
+        role,
+        path: path.to_path_buf(),
+    })
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    debug_assert!(
+        path.is_absolute(),
+        "path should be absolute before normalization"
+    );
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => {
+                normalized.push(std::path::MAIN_SEPARATOR.to_string());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized.file_name().is_some() {
+                    normalized.pop();
+                }
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+
+    normalized
 }
 
 struct SelectedPackage<'a> {
@@ -540,4 +643,72 @@ impl<'a> SelectedPackage<'a> {
 struct ResolvedInput {
     manifest_path: PathBuf,
     default_output_dir: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_str_escapes_control_characters() {
+        assert_eq!(
+            rust_str("line 1\n\"quoted\"\t\\tail"),
+            "\"line 1\\n\\\"quoted\\\"\\t\\\\tail\""
+        );
+    }
+
+    #[test]
+    fn toml_str_escapes_control_characters() {
+        assert_eq!(
+            toml_str("line 1\n\"quoted\"\t\\tail\u{1F}"),
+            "\"line 1\\n\\\"quoted\\\"\\t\\\\tail\\u001F\""
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rust_path_rejects_non_utf8_path() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from(OsString::from_vec(vec![0x66, 0x80, 0x6F]));
+
+        let error = rust_path(&path, "output directory").expect_err("non-UTF-8 path should fail");
+
+        assert!(matches!(
+            error,
+            Error::NonUtf8Path {
+                role: "output directory",
+                ..
+            }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn toml_path_rejects_non_utf8_path() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from(OsString::from_vec(vec![0x66, 0x80, 0x6F]));
+
+        let error =
+            toml_path(&path, "dependency package path").expect_err("non-UTF-8 path should fail");
+
+        assert!(matches!(
+            error,
+            Error::NonUtf8Path {
+                role: "dependency package path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn absolutize_normalizes_cur_dir_components() {
+        let current_dir = env::current_dir().expect("current dir");
+        let normalized = absolutize(Path::new(".").join("Cargo.toml").as_path()).expect("path");
+
+        assert_eq!(normalized, current_dir.join("Cargo.toml"));
+    }
 }

--- a/cargo-statum-graph/src/lib.rs
+++ b/cargo-statum-graph/src/lib.rs
@@ -11,6 +11,7 @@ use cargo_metadata::{Metadata, MetadataCommand, Package, PackageId};
 use tempfile::TempDir;
 
 const GRAPH_EXTENSIONS: [&str; 4] = ["mmd", "dot", "puml", "json"];
+const NO_LINKED_MACHINES_MESSAGE: &str = "statum-graph: no linked state machines were found in the target workspace. This can mean the workspace has no Statum machines, or that it depends on incompatible `statum`, `statum-core`, or `statum-graph` versions so linked inventories do not unify. If you expected machines here, ensure those crates use compatible versions.";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Options {
@@ -463,6 +464,11 @@ fn build_runner_main(
     source.push_str("}\n\n");
     source.push_str("fn run() -> Result<(), Box<dyn std::error::Error>> {\n");
     source.push_str("    let doc = statum_graph::CodebaseDoc::linked()?;\n");
+    source.push_str("    if doc.machines().is_empty() {\n");
+    source.push_str("        return Err(std::io::Error::other(");
+    source.push_str(&rust_str(NO_LINKED_MACHINES_MESSAGE));
+    source.push_str(").into());\n");
+    source.push_str("    }\n");
     source.push_str("    statum_graph::codebase::render::write_all_to_dir(\n");
     source.push_str("        &doc,\n");
     source.push_str(&format!(

--- a/cargo-statum-graph/src/lib.rs
+++ b/cargo-statum-graph/src/lib.rs
@@ -1,0 +1,540 @@
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+
+use cargo_metadata::{Metadata, MetadataCommand, Package, PackageId};
+use tempfile::TempDir;
+
+const GRAPH_EXTENSIONS: [&str; 4] = ["mmd", "dot", "puml", "json"];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Options {
+    pub input_path: PathBuf,
+    pub package: Option<String>,
+    pub out_dir: Option<PathBuf>,
+    pub stem: String,
+    pub patch_statum_root: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    CurrentDir(io::Error),
+    Metadata(cargo_metadata::Error),
+    PackageNotFound {
+        manifest_path: PathBuf,
+        package: String,
+    },
+    AmbiguousPackage {
+        manifest_path: PathBuf,
+        candidates: Vec<String>,
+    },
+    PackageHasNoLibrary {
+        manifest_path: PathBuf,
+        package: String,
+    },
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    RunnerFailed {
+        manifest_path: PathBuf,
+        status: ExitStatus,
+        details: Option<String>,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CurrentDir(source) => {
+                write!(formatter, "failed to read current directory: {source}")
+            }
+            Self::Metadata(source) => write!(formatter, "failed to load cargo metadata: {source}"),
+            Self::PackageNotFound {
+                manifest_path,
+                package,
+            } => write!(
+                formatter,
+                "manifest `{}` does not contain package `{package}`",
+                manifest_path.display()
+            ),
+            Self::AmbiguousPackage {
+                manifest_path,
+                candidates,
+            } => {
+                if candidates.is_empty() {
+                    write!(
+                        formatter,
+                        "manifest `{}` does not contain a library package",
+                        manifest_path.display()
+                    )
+                } else {
+                    write!(
+                        formatter,
+                        "manifest `{}` does not identify one library package; choose one of: {}",
+                        manifest_path.display(),
+                        candidates.join(", ")
+                    )
+                }
+            }
+            Self::PackageHasNoLibrary {
+                manifest_path,
+                package,
+            } => write!(
+                formatter,
+                "package `{package}` from manifest `{}` does not expose a library target",
+                manifest_path.display()
+            ),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => write!(
+                formatter,
+                "failed to {action} `{}`: {source}",
+                path.display()
+            ),
+            Self::RunnerFailed {
+                manifest_path,
+                status,
+                details,
+            } => match details {
+                Some(details) => write!(
+                    formatter,
+                    "codebase export for `{}` failed:\n{details}",
+                    manifest_path.display()
+                ),
+                None => write!(
+                    formatter,
+                    "codebase export for `{}` failed with status {status}",
+                    manifest_path.display()
+                ),
+            },
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CurrentDir(source) => Some(source),
+            Self::Metadata(source) => Some(source),
+            Self::Io { source, .. } => Some(source),
+            Self::PackageNotFound { .. }
+            | Self::AmbiguousPackage { .. }
+            | Self::PackageHasNoLibrary { .. }
+            | Self::RunnerFailed { .. } => None,
+        }
+    }
+}
+
+pub fn run(options: Options) -> Result<Vec<PathBuf>, Error> {
+    let input_path = absolutize(&options.input_path).map_err(Error::CurrentDir)?;
+    let input = resolve_input(&input_path);
+    let metadata = load_metadata(&input.manifest_path)?;
+    let selections = select_packages(&metadata, &input, options.package.as_deref())?;
+    let out_dir = resolve_out_dir(&input, options.out_dir.as_deref())?;
+    let patch_root = match options.patch_statum_root {
+        Some(path) => Some(absolutize(&path).map_err(Error::CurrentDir)?),
+        None => detect_patch_root(),
+    };
+
+    let temp_dir = TempDir::new().map_err(|source| Error::Io {
+        action: "create temporary runner directory",
+        path: env::temp_dir(),
+        source,
+    })?;
+    write_runner_project(
+        temp_dir.path(),
+        &selections,
+        &out_dir,
+        &options.stem,
+        patch_root.as_deref(),
+    )?;
+    run_runner(temp_dir.path().join("Cargo.toml"), &input.manifest_path)?;
+
+    Ok(bundle_paths(&out_dir, &options.stem))
+}
+
+fn load_metadata(manifest_path: &Path) -> Result<Metadata, Error> {
+    MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .no_deps()
+        .exec()
+        .map_err(Error::Metadata)
+}
+
+fn select_packages<'a>(
+    metadata: &'a Metadata,
+    input: &ResolvedInput,
+    requested: Option<&str>,
+) -> Result<Vec<SelectedPackage<'a>>, Error> {
+    let manifest_path = input.manifest_path.as_path();
+    if let Some(package) = requested {
+        let selected = metadata
+            .packages
+            .iter()
+            .find(|candidate| candidate.name.as_ref() == package)
+            .ok_or_else(|| Error::PackageNotFound {
+                manifest_path: manifest_path.to_path_buf(),
+                package: package.to_owned(),
+            })?;
+        return SelectedPackage::new(selected, manifest_path).map(|package| vec![package]);
+    }
+
+    if manifest_path == workspace_root_manifest(metadata) {
+        let mut packages = workspace_packages(metadata, &metadata.workspace_members)
+            .into_iter()
+            .filter(|package| has_library_target(package))
+            .collect::<Vec<_>>();
+        packages.sort_by(|left, right| {
+            left.name
+                .as_ref()
+                .cmp(right.name.as_ref())
+                .then_with(|| left.manifest_path.cmp(&right.manifest_path))
+        });
+
+        if packages.is_empty() {
+            return Err(Error::AmbiguousPackage {
+                manifest_path: manifest_path.to_path_buf(),
+                candidates: Vec::new(),
+            });
+        }
+
+        return packages
+            .into_iter()
+            .map(|package| SelectedPackage::new(package, manifest_path))
+            .collect();
+    }
+
+    if let Some(root_package) = metadata.root_package() {
+        if has_library_target(root_package) {
+            return SelectedPackage::new(root_package, manifest_path).map(|package| vec![package]);
+        }
+    }
+
+    let default_members = workspace_packages(metadata, &metadata.workspace_default_members);
+    let default_library_members = default_members
+        .into_iter()
+        .filter(|package| has_library_target(package))
+        .collect::<Vec<_>>();
+    if default_library_members.len() == 1 {
+        return SelectedPackage::new(default_library_members[0], manifest_path)
+            .map(|package| vec![package]);
+    }
+
+    let workspace_members = workspace_packages(metadata, &metadata.workspace_members);
+    let library_members = workspace_members
+        .into_iter()
+        .filter(|package| has_library_target(package))
+        .collect::<Vec<_>>();
+
+    match library_members.as_slice() {
+        [package] => SelectedPackage::new(package, manifest_path).map(|package| vec![package]),
+        [] => Err(Error::AmbiguousPackage {
+            manifest_path: manifest_path.to_path_buf(),
+            candidates: Vec::new(),
+        }),
+        _ => Err(Error::AmbiguousPackage {
+            manifest_path: manifest_path.to_path_buf(),
+            candidates: library_members
+                .iter()
+                .map(|package| package.name.to_string())
+                .collect(),
+        }),
+    }
+}
+
+fn workspace_root_manifest(metadata: &Metadata) -> PathBuf {
+    metadata.workspace_root.as_std_path().join("Cargo.toml")
+}
+
+fn workspace_packages<'a>(metadata: &'a Metadata, ids: &[PackageId]) -> Vec<&'a Package> {
+    ids.iter()
+        .filter_map(|id| metadata.packages.iter().find(|package| package.id == *id))
+        .collect()
+}
+
+fn has_library_target(package: &Package) -> bool {
+    package.targets.iter().any(|target| {
+        target.kind.iter().any(|kind| {
+            matches!(
+                kind,
+                cargo_metadata::TargetKind::Lib
+                    | cargo_metadata::TargetKind::RLib
+                    | cargo_metadata::TargetKind::DyLib
+            )
+        })
+    })
+}
+
+fn resolve_out_dir(input: &ResolvedInput, out_dir: Option<&Path>) -> Result<PathBuf, Error> {
+    match out_dir {
+        Some(path) => absolutize(path).map_err(Error::CurrentDir),
+        None => Ok(input.default_output_dir.clone()),
+    }
+}
+
+fn detect_patch_root() -> Option<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let candidate = manifest_dir.parent()?;
+    if looks_like_statum_workspace(candidate) {
+        Some(candidate.to_path_buf())
+    } else {
+        None
+    }
+}
+
+fn looks_like_statum_workspace(path: &Path) -> bool {
+    [
+        "Cargo.toml",
+        "statum/Cargo.toml",
+        "statum-core/Cargo.toml",
+        "statum-graph/Cargo.toml",
+        "statum-macros/Cargo.toml",
+    ]
+    .into_iter()
+    .all(|relative| path.join(relative).is_file())
+}
+
+fn resolve_input(path: &Path) -> ResolvedInput {
+    if path.is_dir() {
+        ResolvedInput {
+            manifest_path: path.join("Cargo.toml"),
+            default_output_dir: path.to_path_buf(),
+        }
+    } else {
+        ResolvedInput {
+            manifest_path: path.to_path_buf(),
+            default_output_dir: path
+                .parent()
+                .expect("absolute file path should have a parent")
+                .to_path_buf(),
+        }
+    }
+}
+
+fn write_runner_project(
+    runner_dir: &Path,
+    selections: &[SelectedPackage<'_>],
+    out_dir: &Path,
+    stem: &str,
+    patch_root: Option<&Path>,
+) -> Result<(), Error> {
+    let src_dir = runner_dir.join("src");
+    fs::create_dir_all(&src_dir).map_err(|source| Error::Io {
+        action: "create runner source directory",
+        path: src_dir.clone(),
+        source,
+    })?;
+
+    let manifest_path = runner_dir.join("Cargo.toml");
+    let manifest = build_runner_manifest(selections, patch_root);
+    fs::write(&manifest_path, manifest).map_err(|source| Error::Io {
+        action: "write generated runner manifest",
+        path: manifest_path.clone(),
+        source,
+    })?;
+
+    let main_path = src_dir.join("main.rs");
+    let main = build_runner_main(selections, out_dir, stem);
+    fs::write(&main_path, main).map_err(|source| Error::Io {
+        action: "write generated runner source",
+        path: main_path.clone(),
+        source,
+    })?;
+
+    Ok(())
+}
+
+fn build_runner_manifest(selections: &[SelectedPackage<'_>], patch_root: Option<&Path>) -> String {
+    let mut manifest = String::from(
+        "[package]\nname = \"statum-graph-runner\"\nversion = \"0.0.0\"\nedition = \"2021\"\npublish = false\n\n[dependencies]\n",
+    );
+    for (index, selection) in selections.iter().enumerate() {
+        manifest.push_str(&format!(
+            "{} = {{ package = {}, path = {} }}\n",
+            selection.dependency_alias(index),
+            toml_str(selection.package.name.as_ref()),
+            toml_path(
+                selection
+                    .package
+                    .manifest_path
+                    .as_std_path()
+                    .parent()
+                    .expect("package manifest should have a parent")
+            )
+        ));
+    }
+
+    match patch_root {
+        Some(root) => {
+            manifest.push_str(&format!(
+                "statum-graph = {{ path = {} }}\n",
+                toml_path(root.join("statum-graph"))
+            ));
+            push_patch_tables(&mut manifest, root);
+        }
+        None => {
+            manifest.push_str(&format!(
+                "statum-graph = {{ version = {} }}\n",
+                toml_str(&format!("={}", env!("CARGO_PKG_VERSION")))
+            ));
+        }
+    }
+
+    manifest
+}
+
+fn push_patch_tables(manifest: &mut String, root: &Path) {
+    for source in ["crates-io", "https://github.com/eboody/statum"] {
+        if source == "crates-io" {
+            manifest.push_str("\n[patch.crates-io]\n");
+        } else {
+            manifest.push_str(&format!("\n[patch.{}]\n", toml_str(source)));
+        }
+        for package in [
+            "macro_registry",
+            "module_path_extractor",
+            "statum",
+            "statum-core",
+            "statum-graph",
+            "statum-macros",
+        ] {
+            manifest.push_str(&format!(
+                "{package} = {{ path = {} }}\n",
+                toml_path(root.join(package))
+            ));
+        }
+    }
+}
+
+fn build_runner_main(selections: &[SelectedPackage<'_>], out_dir: &Path, stem: &str) -> String {
+    let mut source = String::from("#[allow(unused_imports)]\n");
+    for (index, selection) in selections.iter().enumerate() {
+        source.push_str(&format!("use {} as _;\n", selection.dependency_alias(index)));
+    }
+    source.push_str("\nfn main() -> std::process::ExitCode {\n");
+    source.push_str("    match run() {\n");
+    source.push_str("        Ok(()) => std::process::ExitCode::SUCCESS,\n");
+    source.push_str("        Err(error) => {\n");
+    source.push_str("            eprintln!(\"{}\", error);\n");
+    source.push_str("            std::process::ExitCode::FAILURE\n");
+    source.push_str("        }\n");
+    source.push_str("    }\n");
+    source.push_str("}\n\n");
+    source.push_str("fn run() -> Result<(), Box<dyn std::error::Error>> {\n");
+    source.push_str("    let doc = statum_graph::CodebaseDoc::linked()?;\n");
+    source.push_str("    statum_graph::codebase::render::write_all_to_dir(\n");
+    source.push_str("        &doc,\n");
+    source.push_str(&format!(
+        "        {},\n",
+        rust_str(&out_dir.to_string_lossy())
+    ));
+    source.push_str(&format!("        {},\n", rust_str(stem)));
+    source.push_str("    )?;\n");
+    source.push_str("    Ok(())\n");
+    source.push_str("}\n");
+    source
+}
+
+fn run_runner(runner_manifest_path: PathBuf, target_manifest_path: &Path) -> Result<(), Error> {
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(&runner_manifest_path)
+        .output()
+        .map_err(|source| Error::Io {
+            action: "run generated cargo runner",
+            path: runner_manifest_path.clone(),
+            source,
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::RunnerFailed {
+            manifest_path: target_manifest_path.to_path_buf(),
+            status: output.status,
+            details: normalize_runner_failure_details(&output.stderr, &output.stdout),
+        })
+    }
+}
+
+fn normalize_runner_failure_details(stderr: &[u8], stdout: &[u8]) -> Option<String> {
+    let text = if stderr.is_empty() {
+        String::from_utf8_lossy(stdout).into_owned()
+    } else {
+        String::from_utf8_lossy(stderr).into_owned()
+    };
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(
+            trimmed
+                .strip_prefix("Error: ")
+                .unwrap_or(trimmed)
+                .to_owned(),
+        )
+    }
+}
+
+fn bundle_paths(out_dir: &Path, stem: &str) -> Vec<PathBuf> {
+    GRAPH_EXTENSIONS
+        .into_iter()
+        .map(|extension| out_dir.join(format!("{stem}.{extension}")))
+        .collect()
+}
+
+fn absolutize(path: &Path) -> io::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(env::current_dir()?.join(path))
+    }
+}
+
+fn toml_path(value: impl AsRef<Path>) -> String {
+    let value = value.as_ref().to_string_lossy();
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn rust_str(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn toml_str(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+struct SelectedPackage<'a> {
+    package: &'a Package,
+}
+
+impl<'a> SelectedPackage<'a> {
+    fn new(package: &'a Package, manifest_path: &Path) -> Result<Self, Error> {
+        if has_library_target(package) {
+            Ok(Self { package })
+        } else {
+            Err(Error::PackageHasNoLibrary {
+                manifest_path: manifest_path.to_path_buf(),
+                package: package.name.to_string(),
+            })
+        }
+    }
+
+    fn dependency_alias(&self, index: usize) -> String {
+        format!("graph_target_{index}")
+    }
+}
+
+struct ResolvedInput {
+    manifest_path: PathBuf,
+    default_output_dir: PathBuf,
+}

--- a/cargo-statum-graph/src/lib.rs
+++ b/cargo-statum-graph/src/lib.rs
@@ -416,7 +416,10 @@ fn push_patch_tables(manifest: &mut String, root: &Path) {
 fn build_runner_main(selections: &[SelectedPackage<'_>], out_dir: &Path, stem: &str) -> String {
     let mut source = String::from("#[allow(unused_imports)]\n");
     for (index, selection) in selections.iter().enumerate() {
-        source.push_str(&format!("use {} as _;\n", selection.dependency_alias(index)));
+        source.push_str(&format!(
+            "use {} as _;\n",
+            selection.dependency_alias(index)
+        ));
     }
     source.push_str("\nfn main() -> std::process::ExitCode {\n");
     source.push_str("    match run() {\n");

--- a/cargo-statum-graph/src/main.rs
+++ b/cargo-statum-graph/src/main.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Args, Parser};
+
+use cargo_statum_graph::{run, Options};
+
+#[derive(Debug, Parser)]
+#[command(name = "cargo-statum-graph")]
+#[command(about = "Generate static Statum graph bundles for existing crates")]
+enum Cli {
+    #[command(name = "codebase")]
+    Codebase(CodebaseArgs),
+}
+
+#[derive(Debug, Args)]
+struct CodebaseArgs {
+    #[arg(value_name = "PATH", default_value = ".")]
+    path: PathBuf,
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+    #[arg(long)]
+    package: Option<String>,
+    #[arg(long)]
+    out_dir: Option<PathBuf>,
+    #[arg(long, default_value = "codebase")]
+    stem: String,
+    #[arg(long)]
+    patch_statum_root: Option<PathBuf>,
+}
+
+fn main() -> ExitCode {
+    match run_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_main() -> Result<(), cargo_statum_graph::Error> {
+    let cli = Cli::parse();
+    let written = match cli {
+        Cli::Codebase(args) => run(Options {
+            input_path: args.manifest_path.unwrap_or(args.path),
+            package: args.package,
+            out_dir: args.out_dir,
+            stem: args.stem,
+            patch_statum_root: args.patch_statum_root,
+        })?,
+    };
+
+    for path in written {
+        println!("{}", path.display());
+    }
+
+    Ok(())
+}

--- a/cargo-statum-graph/src/main.rs
+++ b/cargo-statum-graph/src/main.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -40,7 +41,7 @@ fn main() -> ExitCode {
 }
 
 fn run_main() -> Result<(), cargo_statum_graph::Error> {
-    let cli = Cli::parse();
+    let cli = parse_cli_from(std::env::args_os());
     let written = match cli {
         Cli::Codebase(args) => run(Options {
             input_path: args.manifest_path.unwrap_or(args.path),
@@ -56,4 +57,43 @@ fn run_main() -> Result<(), cargo_statum_graph::Error> {
     }
 
     Ok(())
+}
+
+fn parse_cli_from<I, T>(args: I) -> Cli
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let mut args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+    if args.get(1).is_some_and(|arg| arg == "statum-graph") {
+        args.remove(1);
+    }
+
+    Cli::parse_from(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_from_accepts_direct_binary_shape() {
+        let cli = parse_cli_from(["cargo-statum-graph", "codebase", "/tmp/workspace"]);
+
+        let Cli::Codebase(args) = cli;
+        assert_eq!(args.path, PathBuf::from("/tmp/workspace"));
+    }
+
+    #[test]
+    fn parse_cli_from_accepts_cargo_injected_subcommand_name() {
+        let cli = parse_cli_from([
+            "cargo-statum-graph",
+            "statum-graph",
+            "codebase",
+            "/tmp/workspace",
+        ]);
+
+        let Cli::Codebase(args) = cli;
+        assert_eq!(args.path, PathBuf::from("/tmp/workspace"));
+    }
 }

--- a/cargo-statum-graph/tests/cli.rs
+++ b/cargo-statum-graph/tests/cli.rs
@@ -25,9 +25,11 @@ fn codebase_command_accepts_workspace_dir_and_writes_bundle_into_workspace_root(
 
     assert!(mermaid.contains("graph TD"));
     assert!(mermaid.contains("-.->|state_data|"));
+    assert!(mermaid.contains("WorkflowRow::into_machine()"));
     assert!(dot.contains("style=dashed"));
     assert!(plantuml.contains("@startuml"));
     assert!(json.contains("\"links\""));
+    assert!(json.contains("\"validator_entries\""));
     assert!(json.contains("workflow::Machine"));
     assert!(json.contains("task::Machine"));
 }
@@ -70,7 +72,7 @@ fn write_fixture(dir: &Path) {
         "[package]\nname = \"fixture-domain\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nstatum = { workspace = true }\n";
     let domain_lib = "pub mod task {\n    use statum::{machine, state, transition};\n\n    #[state]\n    pub enum State {\n        Idle,\n        Running,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n\n    #[transition]\n    impl Machine<Idle> {\n        pub fn start(self) -> Machine<Running> {\n            self.transition()\n        }\n    }\n}\n";
     let app_manifest = "[package]\nname = \"fixture-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nfixture-domain = { path = \"../domain\" }\nstatum = { workspace = true }\n";
-    let app_lib = "pub mod workflow {\n    use fixture_domain::task;\n    use statum::{machine, state, transition};\n\n    #[state]\n    pub enum State {\n        Draft,\n        InProgress(task::Machine<task::Running>),\n        Done,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n\n    #[transition]\n    impl Machine<Draft> {\n        pub fn start(self, task: task::Machine<task::Running>) -> Machine<InProgress> {\n            self.transition_with(task)\n        }\n    }\n\n    #[transition]\n    impl Machine<InProgress> {\n        pub fn finish(self) -> Machine<Done> {\n            self.transition()\n        }\n    }\n}\n";
+    let app_lib = "pub mod workflow {\n    use fixture_domain::task;\n    use statum::{Error, machine, state, transition, validators};\n\n    #[state]\n    pub enum State {\n        Draft,\n        InProgress(task::Machine<task::Running>),\n        Done,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n\n    #[transition]\n    impl Machine<Draft> {\n        pub fn start(self, task: task::Machine<task::Running>) -> Machine<InProgress> {\n            self.transition_with(task)\n        }\n    }\n\n    #[transition]\n    impl Machine<InProgress> {\n        pub fn finish(self) -> Machine<Done> {\n            self.transition()\n        }\n    }\n\n    pub struct WorkflowRow {\n        pub status: &'static str,\n    }\n\n    #[validators(Machine)]\n    impl WorkflowRow {\n        fn is_draft(&self) -> statum::Result<()> {\n            if self.status == \"draft\" {\n                Ok(())\n            } else {\n                Err(Error::InvalidState)\n            }\n        }\n\n        fn is_in_progress(&self) -> statum::Result<task::Machine<task::Running>> {\n            if self.status == \"in_progress\" {\n                Ok(task::Machine::<task::Running>::builder().build())\n            } else {\n                Err(Error::InvalidState)\n            }\n        }\n\n        fn is_done(&self) -> statum::Result<()> {\n            if self.status == \"done\" {\n                Ok(())\n            } else {\n                Err(Error::InvalidState)\n            }\n        }\n    }\n}\n";
 
     fs::create_dir_all(dir.join("crates/domain/src")).expect("fixture domain src dir");
     fs::create_dir_all(dir.join("crates/app/src")).expect("fixture app src dir");

--- a/cargo-statum-graph/tests/cli.rs
+++ b/cargo-statum-graph/tests/cli.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+#[test]
+fn codebase_command_accepts_workspace_dir_and_writes_bundle_into_workspace_root() {
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    write_fixture(fixture_dir.path());
+
+    let status = Command::new(env!("CARGO_BIN_EXE_cargo-statum-graph"))
+        .arg("codebase")
+        .arg(fixture_dir.path())
+        .status()
+        .expect("cargo-statum-graph should run");
+    assert!(status.success(), "cargo-statum-graph should succeed");
+
+    let mermaid =
+        fs::read_to_string(fixture_dir.path().join("codebase.mmd")).expect("mermaid output");
+    let dot = fs::read_to_string(fixture_dir.path().join("codebase.dot")).expect("dot output");
+    let plantuml =
+        fs::read_to_string(fixture_dir.path().join("codebase.puml")).expect("plantuml output");
+    let json = fs::read_to_string(fixture_dir.path().join("codebase.json")).expect("json output");
+
+    assert!(mermaid.contains("graph TD"));
+    assert!(mermaid.contains("-.->|state_data|"));
+    assert!(dot.contains("style=dashed"));
+    assert!(plantuml.contains("@startuml"));
+    assert!(json.contains("\"links\""));
+    assert!(json.contains("workflow::Machine"));
+    assert!(json.contains("task::Machine"));
+}
+
+#[test]
+fn codebase_command_fails_closed_for_duplicate_machine_paths_across_workspace_members() {
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    write_duplicate_machine_path_fixture(fixture_dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-statum-graph"))
+        .arg("codebase")
+        .arg(fixture_dir.path())
+        .output()
+        .expect("cargo-statum-graph should run");
+    assert!(
+        !output.status.success(),
+        "duplicate machine paths should fail closed"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duplicate machine path `flow::Machine`"),
+        "stderr should report duplicate machine path, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--package") && stderr.contains("distinct module path"),
+        "stderr should report duplicate machine path, got: {stderr}"
+    );
+}
+
+fn write_fixture(dir: &Path) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate should live under workspace root");
+    let root_manifest = format!(
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/domain\", \"crates/app\"]\n\n[workspace.dependencies]\nstatum = {{ path = {:?} }}\n",
+        workspace_root.join("statum")
+    );
+    let domain_manifest =
+        "[package]\nname = \"fixture-domain\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nstatum = { workspace = true }\n";
+    let domain_lib = "pub mod task {\n    use statum::{machine, state, transition};\n\n    #[state]\n    pub enum State {\n        Idle,\n        Running,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n\n    #[transition]\n    impl Machine<Idle> {\n        pub fn start(self) -> Machine<Running> {\n            self.transition()\n        }\n    }\n}\n";
+    let app_manifest = "[package]\nname = \"fixture-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nfixture-domain = { path = \"../domain\" }\nstatum = { workspace = true }\n";
+    let app_lib = "pub mod workflow {\n    use fixture_domain::task;\n    use statum::{machine, state, transition};\n\n    #[state]\n    pub enum State {\n        Draft,\n        InProgress(task::Machine<task::Running>),\n        Done,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n\n    #[transition]\n    impl Machine<Draft> {\n        pub fn start(self, task: task::Machine<task::Running>) -> Machine<InProgress> {\n            self.transition_with(task)\n        }\n    }\n\n    #[transition]\n    impl Machine<InProgress> {\n        pub fn finish(self) -> Machine<Done> {\n            self.transition()\n        }\n    }\n}\n";
+
+    fs::create_dir_all(dir.join("crates/domain/src")).expect("fixture domain src dir");
+    fs::create_dir_all(dir.join("crates/app/src")).expect("fixture app src dir");
+    fs::write(dir.join("Cargo.toml"), root_manifest).expect("fixture root cargo manifest");
+    fs::write(dir.join("crates/domain/Cargo.toml"), domain_manifest)
+        .expect("fixture domain cargo manifest");
+    fs::write(dir.join("crates/domain/src/lib.rs"), domain_lib).expect("fixture domain lib");
+    fs::write(dir.join("crates/app/Cargo.toml"), app_manifest)
+        .expect("fixture app cargo manifest");
+    fs::write(dir.join("crates/app/src/lib.rs"), app_lib).expect("fixture app lib");
+}
+
+fn write_duplicate_machine_path_fixture(dir: &Path) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate should live under workspace root");
+    let root_manifest = format!(
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/a\", \"crates/b\"]\n\n[workspace.dependencies]\nstatum = {{ path = {:?} }}\n",
+        workspace_root.join("statum")
+    );
+    let crate_manifest_suffix =
+        "version = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nstatum = { workspace = true }\n";
+    let lib_rs = "pub mod flow {\n    use statum::{machine, state};\n\n    #[state]\n    pub enum State {\n        Draft,\n    }\n\n    #[machine]\n    pub struct Machine<State> {}\n}\n";
+
+    fs::create_dir_all(dir.join("crates/a/src")).expect("fixture a src dir");
+    fs::create_dir_all(dir.join("crates/b/src")).expect("fixture b src dir");
+    fs::write(dir.join("Cargo.toml"), root_manifest).expect("fixture root cargo manifest");
+    fs::write(
+        dir.join("crates/a/Cargo.toml"),
+        format!("[package]\nname = \"fixture-a\"\n{crate_manifest_suffix}"),
+    )
+    .expect("fixture a cargo manifest");
+    fs::write(
+        dir.join("crates/b/Cargo.toml"),
+        format!("[package]\nname = \"fixture-b\"\n{crate_manifest_suffix}"),
+    )
+    .expect("fixture b cargo manifest");
+    fs::write(dir.join("crates/a/src/lib.rs"), lib_rs).expect("fixture a lib");
+    fs::write(dir.join("crates/b/src/lib.rs"), lib_rs).expect("fixture b lib");
+}

--- a/cargo-statum-graph/tests/cli.rs
+++ b/cargo-statum-graph/tests/cli.rs
@@ -101,6 +101,36 @@ fn codebase_command_rejects_invalid_output_stem_before_runner_build() {
     assert!(!fixture_dir.path().join("..").join("escape.mmd").exists());
 }
 
+#[test]
+fn codebase_command_fails_closed_when_no_linked_machines_are_found() {
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    write_no_machine_fixture(fixture_dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-statum-graph"))
+        .arg("codebase")
+        .arg(fixture_dir.path())
+        .output()
+        .expect("cargo-statum-graph should run");
+    assert!(
+        !output.status.success(),
+        "missing linked machines should fail closed"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no linked state machines were found in the target workspace"),
+        "stderr should explain the empty linked inventory, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("compatible versions"),
+        "stderr should explain the likely version-mismatch fix, got: {stderr}"
+    );
+    assert!(!fixture_dir.path().join("codebase.mmd").exists());
+    assert!(!fixture_dir.path().join("codebase.dot").exists());
+    assert!(!fixture_dir.path().join("codebase.puml").exists());
+    assert!(!fixture_dir.path().join("codebase.json").exists());
+}
+
 fn write_fixture(dir: &Path) {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -152,4 +182,17 @@ fn write_duplicate_machine_path_fixture(dir: &Path) {
     .expect("fixture b cargo manifest");
     fs::write(dir.join("crates/a/src/lib.rs"), lib_rs).expect("fixture a lib");
     fs::write(dir.join("crates/b/src/lib.rs"), lib_rs).expect("fixture b lib");
+}
+
+fn write_no_machine_fixture(dir: &Path) {
+    let root_manifest = "[workspace]\nresolver = \"2\"\nmembers = [\"crates/app\"]\n".to_owned();
+    let app_manifest =
+        "[package]\nname = \"fixture-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n";
+    let app_lib =
+        "pub struct PlainData {\n    pub id: u32,\n}\n\npub fn answer() -> u32 {\n    42\n}\n";
+
+    fs::create_dir_all(dir.join("crates/app/src")).expect("fixture app src dir");
+    fs::write(dir.join("Cargo.toml"), root_manifest).expect("fixture root cargo manifest");
+    fs::write(dir.join("crates/app/Cargo.toml"), app_manifest).expect("fixture app cargo manifest");
+    fs::write(dir.join("crates/app/src/lib.rs"), app_lib).expect("fixture app lib");
 }

--- a/cargo-statum-graph/tests/cli.rs
+++ b/cargo-statum-graph/tests/cli.rs
@@ -35,6 +35,25 @@ fn codebase_command_accepts_workspace_dir_and_writes_bundle_into_workspace_root(
 }
 
 #[test]
+fn codebase_command_accepts_cargo_style_invocation_from_workspace_root() {
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    write_fixture(fixture_dir.path());
+
+    let status = Command::new(env!("CARGO_BIN_EXE_cargo-statum-graph"))
+        .current_dir(fixture_dir.path())
+        .arg("statum-graph")
+        .arg("codebase")
+        .status()
+        .expect("cargo-style invocation should run");
+    assert!(status.success(), "cargo-style invocation should succeed");
+
+    assert!(fixture_dir.path().join("codebase.mmd").is_file());
+    assert!(fixture_dir.path().join("codebase.dot").is_file());
+    assert!(fixture_dir.path().join("codebase.puml").is_file());
+    assert!(fixture_dir.path().join("codebase.json").is_file());
+}
+
+#[test]
 fn codebase_command_fails_closed_for_duplicate_machine_paths_across_workspace_members() {
     let fixture_dir = tempdir().expect("fixture tempdir");
     write_duplicate_machine_path_fixture(fixture_dir.path());
@@ -58,6 +77,28 @@ fn codebase_command_fails_closed_for_duplicate_machine_paths_across_workspace_me
         stderr.contains("--package") && stderr.contains("distinct module path"),
         "stderr should report duplicate machine path, got: {stderr}"
     );
+}
+
+#[test]
+fn codebase_command_rejects_invalid_output_stem_before_runner_build() {
+    let fixture_dir = tempdir().expect("fixture tempdir");
+    write_fixture(fixture_dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-statum-graph"))
+        .arg("codebase")
+        .arg(fixture_dir.path())
+        .arg("--stem")
+        .arg("../escape")
+        .output()
+        .expect("cargo-statum-graph should run");
+    assert!(!output.status.success(), "invalid stem should fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid output stem `../escape`"),
+        "stderr should report the invalid stem, got: {stderr}"
+    );
+    assert!(!fixture_dir.path().join("..").join("escape.mmd").exists());
 }
 
 fn write_fixture(dir: &Path) {

--- a/cargo-statum-graph/tests/cli.rs
+++ b/cargo-statum-graph/tests/cli.rs
@@ -78,8 +78,7 @@ fn write_fixture(dir: &Path) {
     fs::write(dir.join("crates/domain/Cargo.toml"), domain_manifest)
         .expect("fixture domain cargo manifest");
     fs::write(dir.join("crates/domain/src/lib.rs"), domain_lib).expect("fixture domain lib");
-    fs::write(dir.join("crates/app/Cargo.toml"), app_manifest)
-        .expect("fixture app cargo manifest");
+    fs::write(dir.join("crates/app/Cargo.toml"), app_manifest).expect("fixture app cargo manifest");
     fs::write(dir.join("crates/app/src/lib.rs"), app_lib).expect("fixture app lib");
 }
 

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -106,7 +106,8 @@ outcomes. Validator node labels use the impl self type as written in source, so
 they are human-facing display syntax rather than canonical Rust type identity.
 Method-level `#[cfg]` and `#[cfg_attr]` on validator methods are rejected at
 the macro layer, so the linked validator inventory covers only supported
-compiled validator impl shapes.
+compiled validator impl shapes. Validator impls inside `include!()` files are
+also rejected at the macro layer.
 
 ## Transition Identity
 

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -98,8 +98,15 @@ Mermaid, DOT, PlantUML, or stable JSON output.
 
 For a linked-build codebase view, `statum-graph::CodebaseDoc::linked()` also
 collects every linked compiled machine family and resolves direct machine-like
-payload links written in state data. That combined view is still static. It is
-not a whole-workspace source scan and it does not model runtime orchestration.
+payload links written in state data plus declared validator-entry surfaces from
+compiled `#[validators]` impls. That combined view is still static. It is not a
+whole-workspace source scan, it does not model runtime orchestration, and
+validator entries describe declared rebuild surfaces rather than runtime match
+outcomes. Validator node labels use the impl self type as written in source, so
+they are human-facing display syntax rather than canonical Rust type identity.
+Method-level `#[cfg]` and `#[cfg_attr]` on validator methods are rejected at
+the macro layer, so the linked validator inventory covers only supported
+compiled validator impl shapes.
 
 ## Transition Identity
 

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -92,8 +92,14 @@ From there, a consumer can ask for:
 - the exact legal targets for a transition site
 
 If you want a ready-made static graph export instead of writing your own
-renderer, `statum-graph` builds `MachineDoc` values and Mermaid output directly
-from this graph surface.
+renderer, `statum-graph` builds validated `MachineDoc` values from this graph
+surface, joins optional presentation labels and descriptions, and renders
+Mermaid, DOT, PlantUML, or stable JSON output.
+
+For a linked-build codebase view, `statum-graph::CodebaseDoc::linked()` also
+collects every linked compiled machine family and resolves direct machine-like
+payload links written in state data. That combined view is still static. It is
+not a whole-workspace source scan and it does not model runtime orchestration.
 
 ## Transition Identity
 
@@ -187,6 +193,17 @@ macro-expanded, cfg-pruned items and supported attribute shapes. If a category
 declares `#[presentation_types(...)]`, each annotated item in that category
 must supply `metadata = ...`; otherwise the macro rejects it instead of
 guessing a default value.
+
+`statum-graph` can join those labels and descriptions onto its stable
+`ExportDoc` surface. The built-in JSON renderer keeps arbitrary typed
+`metadata` out of the default output so the exported format stays deterministic
+without requiring every metadata type to be serializable.
+
+For the codebase surface, the same linked compiled observation point applies.
+Machine-local topology comes from the generated machine graph and transition
+inventory. Static cross-machine links come only from direct machine-like
+payload types written in state data. Resolution uses normalized path suffixes
+plus target state names and fails closed on ambiguity instead of guessing.
 
 ## Example
 

--- a/docs/persistence-and-validators.md
+++ b/docs/persistence-and-validators.md
@@ -27,6 +27,10 @@ The important part is what Statum does not generate: it does not treat stored
 data as already trustworthy. Validators decide whether the persisted value
 actually represents `Draft`, `InReview`, `Published`, or nothing legal at all.
 
+Put `#[cfg]` or `#[cfg_attr]` on the whole `#[validators]` impl when you need
+build-specific rebuild surfaces. Statum rejects method-level cfg on
+individual `is_{state}` validators.
+
 ## Pick The Right Entry Point
 
 Use:

--- a/docs/persistence-and-validators.md
+++ b/docs/persistence-and-validators.md
@@ -29,7 +29,8 @@ actually represents `Draft`, `InReview`, `Published`, or nothing legal at all.
 
 Put `#[cfg]` or `#[cfg_attr]` on the whole `#[validators]` impl when you need
 build-specific rebuild surfaces. Statum rejects method-level cfg on
-individual `is_{state}` validators.
+individual `is_{state}` validators. Validator impls inside `include!()` files
+are rejected; keep them inline or in the module source file.
 
 ## Pick The Right Entry Point
 

--- a/statum-core/src/introspection.rs
+++ b/statum-core/src/introspection.rs
@@ -340,6 +340,17 @@ pub fn linked_machines() -> &'static [LinkedMachineGraph] {
     &__STATUM_LINKED_MACHINES
 }
 
+/// Linked compiled validator-entry surfaces visible to the current build.
+#[doc(hidden)]
+#[linkme::distributed_slice]
+pub static __STATUM_LINKED_VALIDATOR_ENTRIES: [LinkedValidatorEntryDescriptor];
+
+/// Returns every linked compiled validator-entry surface visible to the current
+/// build.
+pub fn linked_validator_entries() -> &'static [LinkedValidatorEntryDescriptor] {
+    &__STATUM_LINKED_VALIDATOR_ENTRIES
+}
+
 /// Structural machine graph emitted from macro-generated metadata.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MachineGraph<S: 'static, T: 'static> {
@@ -527,14 +538,27 @@ pub struct StaticMachineLinkDescriptor {
     pub to_state: &'static str,
 }
 
+/// One declared validator-entry surface carried by the linked build inventory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LinkedValidatorEntryDescriptor {
+    /// Rust-facing identity of the rebuilt machine family.
+    pub machine: MachineDescriptor,
+    /// `module_path!()` for the module that owns the `#[validators]` impl.
+    pub source_module_path: &'static str,
+    /// Human-facing source syntax for the persisted impl self type as written.
+    pub source_type_display: &'static str,
+    /// State marker names this `#[validators]` impl can rebuild when it matches.
+    pub target_states: &'static [&'static str],
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
-        LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
-        MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
-        MachineTransitionRecorder, RecordedTransition, StateDescriptor, StatePresentation,
-        StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory,
+        LinkedTransitionInventory, LinkedValidatorEntryDescriptor, MachineDescriptor, MachineGraph,
+        MachineIntrospection, MachinePresentation, MachinePresentationDescriptor,
+        MachineStateIdentity, MachineTransitionRecorder, RecordedTransition, StateDescriptor,
+        StatePresentation, StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory,
         TransitionPresentation, TransitionPresentationInventory,
     };
     use core::marker::PhantomData;
@@ -921,5 +945,23 @@ mod tests {
         );
         assert_eq!(linked.transitions_from("Draft").count(), 1);
         assert_eq!(linked.static_links, &LINKS);
+    }
+
+    #[test]
+    fn linked_validator_entry_descriptor_exposes_declared_surface() {
+        static ENTRY: LinkedValidatorEntryDescriptor = LinkedValidatorEntryDescriptor {
+            machine: MachineDescriptor {
+                module_path: "workflow",
+                rust_type_path: "workflow::Machine",
+            },
+            source_module_path: "workflow::rows",
+            source_type_display: "DbRow",
+            target_states: &["Draft", "Review"],
+        };
+
+        assert_eq!(ENTRY.machine.rust_type_path, "workflow::Machine");
+        assert_eq!(ENTRY.source_module_path, "workflow::rows");
+        assert_eq!(ENTRY.source_type_display, "DbRow");
+        assert_eq!(ENTRY.target_states, &["Draft", "Review"]);
     }
 }

--- a/statum-core/src/introspection.rs
+++ b/statum-core/src/introspection.rs
@@ -100,6 +100,50 @@ impl<T, M> core::cmp::PartialEq for TransitionPresentationInventory<T, M> {
 
 impl<T, M> core::cmp::Eq for TransitionPresentationInventory<T, M> {}
 
+/// Runtime accessor for erased transition descriptors supplied by a
+/// distributed machine inventory.
+#[derive(Clone, Copy)]
+pub struct LinkedTransitionInventory {
+    get: fn() -> &'static [LinkedTransitionDescriptor],
+}
+
+impl LinkedTransitionInventory {
+    /// Creates a linked transition inventory from a `'static` getter.
+    pub const fn new(get: fn() -> &'static [LinkedTransitionDescriptor]) -> Self {
+        Self { get }
+    }
+
+    /// Returns the linked transition descriptors as a slice.
+    pub fn as_slice(&self) -> &'static [LinkedTransitionDescriptor] {
+        (self.get)()
+    }
+}
+
+impl core::ops::Deref for LinkedTransitionInventory {
+    type Target = [LinkedTransitionDescriptor];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl core::fmt::Debug for LinkedTransitionInventory {
+    fn fmt(
+        &self,
+        formatter: &mut core::fmt::Formatter<'_>,
+    ) -> core::result::Result<(), core::fmt::Error> {
+        formatter.debug_tuple("LinkedTransitionInventory").finish()
+    }
+}
+
+impl core::cmp::PartialEq for LinkedTransitionInventory {
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::eq(self.as_slice(), other.as_slice())
+    }
+}
+
+impl core::cmp::Eq for LinkedTransitionInventory {}
+
 /// Identity for one concrete machine state.
 pub trait MachineStateIdentity: MachineIntrospection {
     /// The state id for this concrete machine instantiation.
@@ -286,6 +330,16 @@ pub trait MachineTransitionRecorder: MachineStateIdentity {
 
 impl<M> MachineTransitionRecorder for M where M: MachineStateIdentity {}
 
+/// Linked compiled machine families visible to the current build.
+#[doc(hidden)]
+#[linkme::distributed_slice]
+pub static __STATUM_LINKED_MACHINES: [LinkedMachineGraph];
+
+/// Returns every linked compiled machine family visible to the current build.
+pub fn linked_machines() -> &'static [LinkedMachineGraph] {
+    &__STATUM_LINKED_MACHINES
+}
+
 /// Structural machine graph emitted from macro-generated metadata.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MachineGraph<S: 'static, T: 'static> {
@@ -351,6 +405,54 @@ where
     }
 }
 
+/// Erased machine graph emitted for codebase-level export over the linked
+/// build.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LinkedMachineGraph {
+    /// Rust-facing identity of the machine family.
+    pub machine: MachineDescriptor,
+    /// Optional human-facing machine label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing machine description.
+    pub description: Option<&'static str>,
+    /// All states known to the machine.
+    pub states: &'static [LinkedStateDescriptor],
+    /// All transition sites known to the machine.
+    pub transitions: LinkedTransitionInventory,
+    /// Direct machine-like payload references written in state data.
+    pub static_links: &'static [StaticMachineLinkDescriptor],
+}
+
+impl LinkedMachineGraph {
+    /// Finds a state descriptor by Rust state name.
+    pub fn state(&self, rust_name: &str) -> Option<&LinkedStateDescriptor> {
+        self.states
+            .iter()
+            .find(|state| state.rust_name == rust_name)
+    }
+
+    /// Yields all transition sites originating from `state`.
+    pub fn transitions_from(
+        &self,
+        state: &'static str,
+    ) -> impl Iterator<Item = &LinkedTransitionDescriptor> + '_ {
+        self.transitions
+            .iter()
+            .filter(move |transition| transition.from == state)
+    }
+
+    /// Finds the transition site for `method_name` on `state`.
+    pub fn transition_from_method(
+        &self,
+        state: &'static str,
+        method_name: &str,
+    ) -> Option<&LinkedTransitionDescriptor> {
+        self.transitions
+            .iter()
+            .find(|transition| transition.from == state && transition.method_name == method_name)
+    }
+}
+
 /// Rust-facing identity for a machine family.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MachineDescriptor {
@@ -371,6 +473,19 @@ pub struct StateDescriptor<S: 'static> {
     pub has_data: bool,
 }
 
+/// Erased state descriptor carried by the linked machine inventory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LinkedStateDescriptor {
+    /// Rust variant name of the state marker.
+    pub rust_name: &'static str,
+    /// Optional human-facing state label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing state description.
+    pub description: Option<&'static str>,
+    /// Whether the state carries `state_data`.
+    pub has_data: bool,
+}
+
 /// Static descriptor for one transition site.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TransitionDescriptor<S: 'static, T: 'static> {
@@ -384,13 +499,43 @@ pub struct TransitionDescriptor<S: 'static, T: 'static> {
     pub to: &'static [S],
 }
 
+/// Erased transition descriptor carried by the linked machine inventory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LinkedTransitionDescriptor {
+    /// Rust method name for the transition site.
+    pub method_name: &'static str,
+    /// Optional human-facing transition label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing transition description.
+    pub description: Option<&'static str>,
+    /// Exact source state for the transition site.
+    pub from: &'static str,
+    /// Exact legal target states for the transition site.
+    pub to: &'static [&'static str],
+}
+
+/// One direct machine-like payload reference written in state data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StaticMachineLinkDescriptor {
+    /// Source state that carries the nested machine payload.
+    pub from_state: &'static str,
+    /// Field name for named payloads; `None` for tuple payloads.
+    pub field_name: Option<&'static str>,
+    /// Normalized machine-path suffix segments written in the payload type.
+    pub to_machine_path: &'static [&'static str],
+    /// Target state marker name taken from the payload type's first generic.
+    pub to_state: &'static str,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        MachineDescriptor, MachineGraph, MachineIntrospection, MachinePresentation,
-        MachinePresentationDescriptor, MachineStateIdentity, MachineTransitionRecorder,
-        RecordedTransition, StateDescriptor, StatePresentation, TransitionDescriptor,
-        TransitionInventory, TransitionPresentation, TransitionPresentationInventory,
+        LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
+        LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
+        MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
+        MachineTransitionRecorder, RecordedTransition, StateDescriptor, StatePresentation,
+        StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory,
+        TransitionPresentation, TransitionPresentationInventory,
     };
     use core::marker::PhantomData;
 
@@ -721,5 +866,60 @@ mod tests {
                 },
             })
         );
+    }
+
+    fn linked_transitions() -> &'static [LinkedTransitionDescriptor] {
+        static TRANSITIONS: [LinkedTransitionDescriptor; 1] = [LinkedTransitionDescriptor {
+            method_name: "submit",
+            label: Some("Submit"),
+            description: None,
+            from: "Draft",
+            to: &["Review"],
+        }];
+        &TRANSITIONS
+    }
+
+    #[test]
+    fn linked_machine_graph_helpers_work() {
+        static STATES: [LinkedStateDescriptor; 2] = [
+            LinkedStateDescriptor {
+                rust_name: "Draft",
+                label: None,
+                description: None,
+                has_data: false,
+            },
+            LinkedStateDescriptor {
+                rust_name: "Review",
+                label: Some("Review"),
+                description: None,
+                has_data: true,
+            },
+        ];
+        static LINKS: [StaticMachineLinkDescriptor; 1] = [StaticMachineLinkDescriptor {
+            from_state: "Review",
+            field_name: None,
+            to_machine_path: &["task", "Machine"],
+            to_state: "Running",
+        }];
+
+        let linked = LinkedMachineGraph {
+            machine: MachineDescriptor {
+                module_path: "workflow",
+                rust_type_path: "workflow::Machine",
+            },
+            label: Some("Workflow"),
+            description: None,
+            states: &STATES,
+            transitions: LinkedTransitionInventory::new(linked_transitions),
+            static_links: &LINKS,
+        };
+
+        assert_eq!(linked.state("Review"), Some(&STATES[1]));
+        assert_eq!(
+            linked.transition_from_method("Draft", "submit"),
+            Some(&linked_transitions()[0])
+        );
+        assert_eq!(linked.transitions_from("Draft").count(), 1);
+        assert_eq!(linked.static_links, &LINKS);
     }
 }

--- a/statum-core/src/lib.rs
+++ b/statum-core/src/lib.rs
@@ -19,11 +19,16 @@ mod introspection;
 pub mod projection;
 
 #[doc(hidden)]
+pub use introspection::__STATUM_LINKED_MACHINES;
+
+#[doc(hidden)]
 pub mod __private {
     pub use crate::{
-        MachinePresentation, MachinePresentationDescriptor, RebuildAttempt, RebuildReport,
-        StateFamily, StateFamilyMember, StatePresentation, TransitionPresentation,
-        TransitionPresentationInventory,
+        LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
+        LinkedTransitionInventory, MachinePresentation, MachinePresentationDescriptor,
+        RebuildAttempt, RebuildReport, StateFamily, StateFamilyMember, StatePresentation,
+        StaticMachineLinkDescriptor, TransitionPresentation, TransitionPresentationInventory,
+        __STATUM_LINKED_MACHINES,
     };
     pub use futures;
     pub use linkme;
@@ -47,10 +52,12 @@ pub mod __private {
 }
 
 pub use introspection::{
-    MachineDescriptor, MachineGraph, MachineIntrospection, MachinePresentation,
-    MachinePresentationDescriptor, MachineStateIdentity, MachineTransitionRecorder,
-    RecordedTransition, StateDescriptor, StatePresentation, TransitionDescriptor,
-    TransitionInventory, TransitionPresentation, TransitionPresentationInventory,
+    linked_machines, LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
+    LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
+    MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
+    MachineTransitionRecorder, RecordedTransition, StateDescriptor, StatePresentation,
+    StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory, TransitionPresentation,
+    TransitionPresentationInventory,
 };
 
 /// Hidden family-level metadata emitted by `#[state]`.

--- a/statum-core/src/lib.rs
+++ b/statum-core/src/lib.rs
@@ -20,15 +20,18 @@ pub mod projection;
 
 #[doc(hidden)]
 pub use introspection::__STATUM_LINKED_MACHINES;
+#[doc(hidden)]
+pub use introspection::__STATUM_LINKED_VALIDATOR_ENTRIES;
 
 #[doc(hidden)]
 pub mod __private {
     pub use crate::{
         LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
-        LinkedTransitionInventory, MachinePresentation, MachinePresentationDescriptor,
-        RebuildAttempt, RebuildReport, StateFamily, StateFamilyMember, StatePresentation,
-        StaticMachineLinkDescriptor, TransitionPresentation, TransitionPresentationInventory,
-        __STATUM_LINKED_MACHINES,
+        LinkedTransitionInventory, LinkedValidatorEntryDescriptor, MachinePresentation,
+        MachinePresentationDescriptor, RebuildAttempt, RebuildReport, StateFamily,
+        StateFamilyMember, StatePresentation, StaticMachineLinkDescriptor, TransitionPresentation,
+        TransitionPresentationInventory, __STATUM_LINKED_MACHINES,
+        __STATUM_LINKED_VALIDATOR_ENTRIES,
     };
     pub use futures;
     pub use linkme;
@@ -52,11 +55,12 @@ pub mod __private {
 }
 
 pub use introspection::{
-    linked_machines, LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
-    LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
-    MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
-    MachineTransitionRecorder, RecordedTransition, StateDescriptor, StatePresentation,
-    StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory, TransitionPresentation,
+    linked_machines, linked_validator_entries, LinkedMachineGraph, LinkedStateDescriptor,
+    LinkedTransitionDescriptor, LinkedTransitionInventory, LinkedValidatorEntryDescriptor,
+    MachineDescriptor, MachineGraph, MachineIntrospection, MachinePresentation,
+    MachinePresentationDescriptor, MachineStateIdentity, MachineTransitionRecorder,
+    RecordedTransition, StateDescriptor, StatePresentation, StaticMachineLinkDescriptor,
+    TransitionDescriptor, TransitionInventory, TransitionPresentation,
     TransitionPresentationInventory,
 };
 

--- a/statum-graph/Cargo.toml
+++ b/statum-graph/Cargo.toml
@@ -2,8 +2,16 @@
 path = "../statum"
 version = "0.6.9"
 
+[dependencies.serde]
+features = ["derive"]
+version = "1"
+
+[dependencies.serde_json]
+version = "1"
+
 [dev-dependencies]
 insta = "1.43"
+tempfile = "3"
 
 [package]
 authors = ["Eran Boodnero <eran@eran.codes>"]

--- a/statum-graph/README.md
+++ b/statum-graph/README.md
@@ -9,12 +9,16 @@ It is authoritative only for machine-local structure:
 - states
 - transition sites
 - exact legal targets
-- roots derivable from the static graph itself
+- graph roots derivable from the static graph itself
 
 For linked-build codebase export, `statum-graph` can also combine every linked
 compiled machine family plus direct machine-like payload links written in state
-data. That codebase view is still static only. It does not model runtime-
-selected branches or orchestration order across machines.
+data and declared validator-entry surfaces emitted by compiled
+`#[validators]` impls. That codebase view is still static only. It does not
+model runtime-selected branches or orchestration order across machines.
+Validator node labels come from the impl self type as written in source and are
+display-only, not canonical Rust type identity. Method-level `#[cfg]` and
+`#[cfg_attr]` on validator methods are rejected at the macro layer.
 
 ## Install
 
@@ -269,10 +273,12 @@ assert_eq!(paths.len(), 4);
 
 The codebase view is based on the linked compiled build, not a source scan.
 Static cross-machine links come only from direct machine-like payload types
-written in state data, including named fields. They resolve by normalized path
-suffix plus target state name and fail closed on ambiguity. Wrapper aliases,
-runtime composition, and arbitrary payload-type inference are intentionally out
-of scope.
+written in state data, including named fields. Validator-entry nodes come only
+from compiled `#[validators]` impls and represent declared rebuild surfaces
+such as `DbRow::into_machine()`, not runtime match outcomes. Both surfaces fail
+closed on malformed or ambiguous linked metadata. Wrapper aliases, runtime
+composition, builder overlays, and terminal-state semantics are intentionally
+out of scope.
 
 If you do not want to hand-write a runner crate, install
 `cargo-statum-graph` and point it at an existing library package:

--- a/statum-graph/README.md
+++ b/statum-graph/README.md
@@ -19,6 +19,7 @@ model runtime-selected branches or orchestration order across machines.
 Validator node labels come from the impl self type as written in source and are
 display-only, not canonical Rust type identity. Method-level `#[cfg]` and
 `#[cfg_attr]` on validator methods are rejected at the macro layer.
+`include!()`-generated validator impls are also rejected.
 
 ## Install
 

--- a/statum-graph/README.md
+++ b/statum-graph/README.md
@@ -11,8 +11,10 @@ It is authoritative only for machine-local structure:
 - exact legal targets
 - roots derivable from the static graph itself
 
-It does not model runtime-selected branches, orchestration across multiple
-machines, or consumer-owned explanation metadata.
+For linked-build codebase export, `statum-graph` can also combine every linked
+compiled machine family plus direct machine-like payload links written in state
+data. That codebase view is still static only. It does not model runtime-
+selected branches or orchestration order across machines.
 
 ## Install
 
@@ -95,6 +97,245 @@ graph TD
 
 The output is deterministic for one validated `MachineDoc`, so it works well
 for snapshot tests, generated docs, and CLI output.
+
+## Canonical Export Model
+
+`MachineDoc` is the validated typed graph surface. `ExportDoc` is the stable
+renderer-facing model built from that graph:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::MachineDoc;
+# #[state]
+# enum FlowState {
+#     Draft,
+#     Review,
+#     Accepted,
+# }
+# #[machine]
+# struct Flow<FlowState> {}
+# #[transition]
+# impl Flow<Draft> {
+#     fn submit(self) -> Flow<Review> {
+#         self.transition()
+#     }
+# }
+# #[transition]
+# impl Flow<Review> {
+#     fn accept(self) -> Flow<Accepted> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+let export = doc.export();
+
+assert_eq!(export.states()[0].index, 0);
+assert_eq!(export.transitions()[0].method_name, "submit");
+```
+
+If you have matching `MachinePresentation` metadata, join it onto the export
+surface before rendering:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::{render, MachineDoc};
+# #[state]
+# enum PresentedState {
+#     #[present(label = "Queued")]
+#     Queued,
+#     Done,
+# }
+# #[machine]
+# #[present(label = "Presented Flow")]
+# struct PresentedFlow<PresentedState> {}
+# #[transition]
+# impl PresentedFlow<Queued> {
+#     #[present(label = "Finish")]
+#     fn finish(self) -> PresentedFlow<Done> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<PresentedFlow<Queued>>();
+let export = doc.export_with_presentation(&presented_flow::PRESENTATION)?;
+
+assert_eq!(export.machine().label, Some("Presented Flow"));
+assert_eq!(render::mermaid(&export).contains("Finish"), true);
+# Ok::<(), statum_graph::ExportDocError>(())
+```
+
+Presentation metadata can change labels and descriptions, but the structure
+still comes from `MachineIntrospection::GRAPH`.
+
+## Other Renderers
+
+The same `ExportDoc` drives every built-in renderer:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::{render, MachineDoc};
+# #[state]
+# enum FlowState {
+#     Draft,
+#     Done,
+# }
+# #[machine]
+# struct Flow<FlowState> {}
+# #[transition]
+# impl Flow<Draft> {
+#     fn finish(self) -> Flow<Done> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+let export = doc.export();
+
+let mermaid = render::mermaid(&export);
+let dot = render::dot(&export);
+let plantuml = render::plantuml(&export);
+let json = render::json(&export);
+
+assert!(mermaid.contains("graph TD"));
+assert!(dot.contains("digraph"));
+assert!(plantuml.contains("@startuml"));
+assert!(json.contains("\"transitions\""));
+```
+
+The JSON renderer is stable and pretty-printed. It exports machine identity,
+states, transition sites, exact legal targets, roots, and optional labels and
+descriptions. It does not serialize arbitrary typed `metadata` payloads from
+`MachinePresentation`; those stay application-owned unless you define a
+separate serialization contract.
+
+## Codebase Export
+
+If you want one combined graph for the linked build instead of one machine at a
+time, use `CodebaseDoc`:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::CodebaseDoc;
+# mod task {
+#     use statum::{machine, state, transition};
+#     #[state]
+#     pub enum State {
+#         Idle,
+#         Running,
+#     }
+#     #[machine]
+#     pub struct Machine<State> {}
+#     #[transition]
+#     impl Machine<Idle> {
+#         fn start(self) -> Machine<Running> {
+#             self.transition()
+#         }
+#     }
+# }
+# mod workflow {
+#     use super::task;
+#     use statum::{machine, state, transition};
+#     #[state]
+#     pub enum State {
+#         Draft,
+#         InProgress(task::Machine<task::Running>),
+#     }
+#     #[machine]
+#     pub struct Machine<State> {}
+#     #[transition]
+#     impl Machine<Draft> {
+#         fn start(self, task: task::Machine<task::Running>) -> Machine<InProgress> {
+#             self.transition_with(task)
+#         }
+#     }
+# }
+let codebase = CodebaseDoc::linked()?;
+
+assert!(codebase.machines().len() >= 2);
+assert!(!codebase.links().is_empty());
+# Ok::<(), statum_graph::CodebaseDocError>(())
+```
+
+Render or write the combined document through `statum_graph::codebase::render`:
+
+```rust
+# use statum_graph::{CodebaseDoc, codebase::render};
+# let doc = CodebaseDoc::linked()?;
+let mermaid = render::mermaid(&doc);
+let paths = render::write_all_to_dir(&doc, "out", "codebase")?;
+
+assert!(mermaid.contains("graph TD"));
+assert_eq!(paths.len(), 4);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The codebase view is based on the linked compiled build, not a source scan.
+Static cross-machine links come only from direct machine-like payload types
+written in state data, including named fields. They resolve by normalized path
+suffix plus target state name and fail closed on ambiguity. Wrapper aliases,
+runtime composition, and arbitrary payload-type inference are intentionally out
+of scope.
+
+If you do not want to hand-write a runner crate, install
+`cargo-statum-graph` and point it at an existing library package:
+
+```text
+cargo statum-graph codebase \
+  /path/to/workspace
+```
+
+That command synthesizes the runner internally and writes the same four-file
+bundle into the workspace root without requiring exporter code in the target
+crate. Use `--out-dir` to override the destination or `--package` to narrow a
+multi-package workspace to one library crate.
+
+## Writing Files
+
+You can also write one file directly:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::{render, MachineDoc};
+# #[state]
+# enum FlowState {
+#     Draft,
+#     Done,
+# }
+# #[machine]
+# struct Flow<FlowState> {}
+# #[transition]
+# impl Flow<Draft> {
+#     fn finish(self) -> Flow<Done> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+render::Format::Mermaid.write_to(&doc, "out/flow.mmd")?;
+# Ok::<(), std::io::Error>(())
+```
+
+Or write the whole built-in bundle with standard extensions:
+
+```rust
+# use statum::{machine, state, transition};
+# use statum_graph::{render, MachineDoc};
+# #[state]
+# enum FlowState {
+#     Draft,
+#     Done,
+# }
+# #[machine]
+# struct Flow<FlowState> {}
+# #[transition]
+# impl Flow<Draft> {
+#     fn finish(self) -> Flow<Done> {
+#         self.transition()
+#     }
+# }
+let doc = MachineDoc::from_machine::<Flow<Draft>>();
+let paths = render::write_all_to_dir(&doc, "out", "flow")?;
+
+assert_eq!(paths.len(), 4);
+# Ok::<(), std::io::Error>(())
+```
 
 ## Traversing A Graph
 
@@ -179,6 +420,10 @@ adapters.
 - duplicate target states within one transition
 
 The error surface is `MachineDocError`.
+
+If you join presentation metadata onto a validated machine graph, malformed
+presentation overlays fail closed with `ExportDocError` instead of picking a
+best-effort winner.
 
 ## Scope
 

--- a/statum-graph/src/codebase/mod.rs
+++ b/statum-graph/src/codebase/mod.rs
@@ -562,19 +562,18 @@ fn compare_transitions(
     left: &statum::LinkedTransitionDescriptor,
     right: &statum::LinkedTransitionDescriptor,
 ) -> core::cmp::Ordering {
-    let left_from = state_positions
-        .get(left.from)
-        .copied()
-        .expect("linked transition source should exist");
-    let right_from = state_positions
-        .get(right.from)
-        .copied()
-        .expect("linked transition source should exist");
+    transition_sort_key(state_positions, left).cmp(&transition_sort_key(state_positions, right))
+}
 
-    left_from
-        .cmp(&right_from)
-        .then_with(|| left.method_name.cmp(right.method_name))
-        .then_with(|| left.to.cmp(right.to))
+fn transition_sort_key(
+    state_positions: &HashMap<&'static str, usize>,
+    transition: &statum::LinkedTransitionDescriptor,
+) -> (Option<usize>, &'static str, &'static [&'static str]) {
+    (
+        state_positions.get(transition.from).copied(),
+        transition.method_name,
+        transition.to,
+    )
 }
 
 fn resolve_static_links(

--- a/statum-graph/src/codebase/mod.rs
+++ b/statum-graph/src/codebase/mod.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
-use statum::{LinkedMachineGraph, StaticMachineLinkDescriptor};
+use statum::{LinkedMachineGraph, LinkedValidatorEntryDescriptor, StaticMachineLinkDescriptor};
 
 pub mod render;
 
@@ -17,13 +17,25 @@ impl CodebaseDoc {
     /// Builds a combined codebase document from every linked machine visible to
     /// the current build.
     pub fn linked() -> Result<Self, CodebaseDocError> {
-        Self::try_from_linked(statum::linked_machines())
+        Self::try_from_linked_with_validator_entries(
+            statum::linked_machines(),
+            statum::linked_validator_entries(),
+        )
     }
 
     /// Builds a combined codebase document from an explicit linked machine
     /// inventory.
     pub fn try_from_linked(
         linked: &'static [LinkedMachineGraph],
+    ) -> Result<Self, CodebaseDocError> {
+        Self::try_from_linked_with_validator_entries(linked, &[])
+    }
+
+    /// Builds a combined codebase document from explicit linked machine and
+    /// validator-entry inventories.
+    pub fn try_from_linked_with_validator_entries(
+        linked: &'static [LinkedMachineGraph],
+        validator_entries: &'static [LinkedValidatorEntryDescriptor],
     ) -> Result<Self, CodebaseDocError> {
         let mut linked = linked.to_vec();
         linked.sort_by(|left, right| {
@@ -48,7 +60,14 @@ impl CodebaseDoc {
             static_links.push(built_links);
         }
 
+        let resolved_validator_entries =
+            resolve_validator_entries(&mut machines, validator_entries)?;
         let links = resolve_static_links(&machines, &static_links)?;
+
+        debug_assert_eq!(
+            resolved_validator_entries,
+            total_validator_entries(&machines)
+        );
 
         Ok(Self { machines, links })
     }
@@ -86,6 +105,8 @@ pub struct CodebaseMachine {
     pub states: Vec<CodebaseState>,
     /// Transition sites exported in deterministic order.
     pub transitions: Vec<CodebaseTransition>,
+    /// Declared validator-entry surfaces exported in deterministic order.
+    pub validator_entries: Vec<CodebaseValidatorEntry>,
 }
 
 impl CodebaseMachine {
@@ -101,9 +122,20 @@ impl CodebaseMachine {
             .find(|state| state.rust_name == rust_name)
     }
 
+    /// Returns one exported validator-entry surface by its stable machine-local
+    /// index.
+    pub fn validator_entry(&self, index: usize) -> Option<&CodebaseValidatorEntry> {
+        self.validator_entries.get(index)
+    }
+
     /// Stable renderer node id for one state in this machine.
     pub fn node_id(&self, state_index: usize) -> String {
         format!("m{}_s{}", self.index, state_index)
+    }
+
+    /// Stable renderer node id for one validator entry in this machine.
+    pub fn validator_node_id(&self, entry_index: usize) -> String {
+        format!("m{}_v{}", self.index, entry_index)
     }
 
     fn cluster_id(&self) -> String {
@@ -132,7 +164,7 @@ pub struct CodebaseState {
     /// Whether the state carries `state_data`.
     pub has_data: bool,
     /// Whether the state has no incoming transition in its machine.
-    pub is_root: bool,
+    pub is_graph_root: bool,
 }
 
 impl CodebaseState {
@@ -143,6 +175,26 @@ impl CodebaseState {
             None if self.has_data => Cow::Owned(format!("{} (data)", self.rust_name)),
             None => Cow::Borrowed(self.rust_name),
         }
+    }
+}
+
+/// One declared validator-entry surface in the codebase export surface.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseValidatorEntry {
+    /// Stable machine-local validator-entry index.
+    pub index: usize,
+    /// `module_path!()` for the module that owns the `#[validators]` impl.
+    pub source_module_path: &'static str,
+    /// Human-facing source syntax for the persisted impl self type as written.
+    pub source_type_display: &'static str,
+    /// Stable target-state indices in machine state order.
+    pub target_states: Vec<usize>,
+}
+
+impl CodebaseValidatorEntry {
+    /// Human-facing node label used by text renderers.
+    pub fn display_label(&self) -> Cow<'static, str> {
+        Cow::Owned(format!("{}::into_machine()", self.source_type_display))
     }
 }
 
@@ -234,6 +286,41 @@ pub enum CodebaseDocError {
         transition: &'static str,
         state: &'static str,
     },
+    /// One validator-entry surface points at a machine missing from the linked
+    /// machine inventory.
+    MissingValidatorMachine {
+        machine: &'static str,
+        source_module_path: &'static str,
+        source_type_display: &'static str,
+    },
+    /// One validator-entry surface points at a target state missing from the
+    /// linked machine state list.
+    MissingValidatorTargetState {
+        machine: &'static str,
+        source_module_path: &'static str,
+        source_type_display: &'static str,
+        state: &'static str,
+    },
+    /// One validator-entry surface declares no target states.
+    EmptyValidatorTargetSet {
+        machine: &'static str,
+        source_module_path: &'static str,
+        source_type_display: &'static str,
+    },
+    /// One validator-entry surface lists the same target state more than once.
+    DuplicateValidatorTargetState {
+        machine: &'static str,
+        source_module_path: &'static str,
+        source_type_display: &'static str,
+        state: &'static str,
+    },
+    /// One validator-entry surface appears more than once for the same machine
+    /// and impl site.
+    DuplicateValidatorEntry {
+        machine: &'static str,
+        source_module_path: &'static str,
+        source_type_display: &'static str,
+    },
     /// One static payload link points at a source state missing from the
     /// machine state list.
     MissingStaticLinkSourceState {
@@ -295,6 +382,48 @@ Fix: rerun with `--package` to export one crate, or move one machine to a distin
                 formatter,
                 "linked machine `{machine}` contains transition `{transition}` with duplicate target state `{state}`"
             ),
+            Self::MissingValidatorMachine {
+                machine,
+                source_module_path,
+                source_type_display,
+            } => write!(
+                formatter,
+                "linked validator entry `{source_type_display}::into_machine()` from module `{source_module_path}` points at missing machine `{machine}`"
+            ),
+            Self::MissingValidatorTargetState {
+                machine,
+                source_module_path,
+                source_type_display,
+                state,
+            } => write!(
+                formatter,
+                "linked validator entry `{source_type_display}::into_machine()` from module `{source_module_path}` points at missing state `{machine}::{state}`"
+            ),
+            Self::EmptyValidatorTargetSet {
+                machine,
+                source_module_path,
+                source_type_display,
+            } => write!(
+                formatter,
+                "linked validator entry `{source_type_display}::into_machine()` from module `{source_module_path}` for machine `{machine}` contains no target states"
+            ),
+            Self::DuplicateValidatorTargetState {
+                machine,
+                source_module_path,
+                source_type_display,
+                state,
+            } => write!(
+                formatter,
+                "linked validator entry `{source_type_display}::into_machine()` from module `{source_module_path}` for machine `{machine}` contains duplicate target state `{state}`"
+            ),
+            Self::DuplicateValidatorEntry {
+                machine,
+                source_module_path,
+                source_type_display,
+            } => write!(
+                formatter,
+                "linked validator entry `{source_type_display}::into_machine()` from module `{source_module_path}` appears more than once for machine `{machine}`"
+            ),
             Self::MissingStaticLinkSourceState { machine, state } => write!(
                 formatter,
                 "linked machine `{machine}` contains a static payload link from missing source state `{state}`"
@@ -347,7 +476,7 @@ fn build_machine(
             label: state.label,
             description: state.description,
             has_data: state.has_data,
-            is_root: true,
+            is_graph_root: true,
         });
     }
 
@@ -410,7 +539,7 @@ fn build_machine(
     }
 
     for state in &mut states {
-        state.is_root = !incoming.contains(&state.index);
+        state.is_graph_root = !incoming.contains(&state.index);
     }
 
     Ok((
@@ -422,6 +551,7 @@ fn build_machine(
             description: linked.description,
             states,
             transitions: exported_transitions,
+            validator_entries: Vec::new(),
         },
         linked.static_links.iter().collect(),
     ))
@@ -503,6 +633,103 @@ fn resolve_static_links(
     }
 
     Ok(links)
+}
+
+fn resolve_validator_entries(
+    machines: &mut [CodebaseMachine],
+    validator_entries: &'static [LinkedValidatorEntryDescriptor],
+) -> Result<usize, CodebaseDocError> {
+    let mut validator_entries = validator_entries.to_vec();
+    validator_entries.sort_by(compare_validator_entries);
+
+    let machine_positions = machines
+        .iter()
+        .map(|machine| (machine.rust_type_path, machine.index))
+        .collect::<HashMap<_, _>>();
+    let mut seen_entries = HashSet::with_capacity(validator_entries.len());
+
+    for entry in validator_entries {
+        let Some(&machine_index) = machine_positions.get(entry.machine.rust_type_path) else {
+            return Err(CodebaseDocError::MissingValidatorMachine {
+                machine: entry.machine.rust_type_path,
+                source_module_path: entry.source_module_path,
+                source_type_display: entry.source_type_display,
+            });
+        };
+        if !seen_entries.insert((
+            entry.machine.rust_type_path,
+            entry.source_module_path,
+            entry.source_type_display,
+        )) {
+            return Err(CodebaseDocError::DuplicateValidatorEntry {
+                machine: entry.machine.rust_type_path,
+                source_module_path: entry.source_module_path,
+                source_type_display: entry.source_type_display,
+            });
+        }
+        if entry.target_states.is_empty() {
+            return Err(CodebaseDocError::EmptyValidatorTargetSet {
+                machine: entry.machine.rust_type_path,
+                source_module_path: entry.source_module_path,
+                source_type_display: entry.source_type_display,
+            });
+        }
+
+        let machine = &mut machines[machine_index];
+        let mut target_states = Vec::with_capacity(entry.target_states.len());
+        let mut seen_target_states = HashSet::with_capacity(entry.target_states.len());
+
+        for target_state in entry.target_states {
+            let Some(target_index) = machine.state_named(target_state).map(|state| state.index)
+            else {
+                return Err(CodebaseDocError::MissingValidatorTargetState {
+                    machine: machine.rust_type_path,
+                    source_module_path: entry.source_module_path,
+                    source_type_display: entry.source_type_display,
+                    state: target_state,
+                });
+            };
+            if !seen_target_states.insert(*target_state) {
+                return Err(CodebaseDocError::DuplicateValidatorTargetState {
+                    machine: machine.rust_type_path,
+                    source_module_path: entry.source_module_path,
+                    source_type_display: entry.source_type_display,
+                    state: target_state,
+                });
+            }
+            target_states.push(target_index);
+        }
+
+        target_states.sort_unstable();
+
+        machine.validator_entries.push(CodebaseValidatorEntry {
+            index: machine.validator_entries.len(),
+            source_module_path: entry.source_module_path,
+            source_type_display: entry.source_type_display,
+            target_states,
+        });
+    }
+
+    Ok(total_validator_entries(machines))
+}
+
+fn total_validator_entries(machines: &[CodebaseMachine]) -> usize {
+    machines
+        .iter()
+        .map(|machine| machine.validator_entries.len())
+        .sum()
+}
+
+fn compare_validator_entries(
+    left: &LinkedValidatorEntryDescriptor,
+    right: &LinkedValidatorEntryDescriptor,
+) -> core::cmp::Ordering {
+    left.machine
+        .rust_type_path
+        .cmp(right.machine.rust_type_path)
+        .then_with(|| left.source_module_path.cmp(right.source_module_path))
+        .then_with(|| left.source_type_display.cmp(right.source_type_display))
+        .then_with(|| left.target_states.cmp(right.target_states))
 }
 
 fn path_suffix_matches(candidate: &str, suffix: &[&'static str]) -> bool {

--- a/statum-graph/src/codebase/mod.rs
+++ b/statum-graph/src/codebase/mod.rs
@@ -1,0 +1,511 @@
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+use statum::{LinkedMachineGraph, StaticMachineLinkDescriptor};
+
+pub mod render;
+
+/// Stable export model for the linked compiled machine inventory.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseDoc {
+    machines: Vec<CodebaseMachine>,
+    links: Vec<CodebaseLink>,
+}
+
+impl CodebaseDoc {
+    /// Builds a combined codebase document from every linked machine visible to
+    /// the current build.
+    pub fn linked() -> Result<Self, CodebaseDocError> {
+        Self::try_from_linked(statum::linked_machines())
+    }
+
+    /// Builds a combined codebase document from an explicit linked machine
+    /// inventory.
+    pub fn try_from_linked(
+        linked: &'static [LinkedMachineGraph],
+    ) -> Result<Self, CodebaseDocError> {
+        let mut linked = linked.to_vec();
+        linked.sort_by(|left, right| {
+            left.machine
+                .rust_type_path
+                .cmp(right.machine.rust_type_path)
+        });
+
+        let mut machines = Vec::with_capacity(linked.len());
+        let mut machine_paths = HashSet::with_capacity(linked.len());
+        let mut static_links = Vec::with_capacity(linked.len());
+
+        for (machine_index, machine) in linked.iter().enumerate() {
+            if !machine_paths.insert(machine.machine.rust_type_path) {
+                return Err(CodebaseDocError::DuplicateMachine {
+                    machine: machine.machine.rust_type_path,
+                });
+            }
+
+            let (built_machine, built_links) = build_machine(machine_index, *machine)?;
+            machines.push(built_machine);
+            static_links.push(built_links);
+        }
+
+        let links = resolve_static_links(&machines, &static_links)?;
+
+        Ok(Self { machines, links })
+    }
+
+    /// Exported machines in stable codebase order.
+    pub fn machines(&self) -> &[CodebaseMachine] {
+        &self.machines
+    }
+
+    /// Resolved static cross-machine links in stable order.
+    pub fn links(&self) -> &[CodebaseLink] {
+        &self.links
+    }
+
+    /// Returns one exported machine by its stable codebase index.
+    pub fn machine(&self, index: usize) -> Option<&CodebaseMachine> {
+        self.machines.get(index)
+    }
+}
+
+/// One machine family in the codebase export surface.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseMachine {
+    /// Stable codebase-local machine index.
+    pub index: usize,
+    /// `module_path!()` for the source module that owns the machine.
+    pub module_path: &'static str,
+    /// Fully qualified Rust type path for the machine family.
+    pub rust_type_path: &'static str,
+    /// Optional human-facing machine label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing machine description.
+    pub description: Option<&'static str>,
+    /// States exported in source order.
+    pub states: Vec<CodebaseState>,
+    /// Transition sites exported in deterministic order.
+    pub transitions: Vec<CodebaseTransition>,
+}
+
+impl CodebaseMachine {
+    /// Returns one exported state by its stable state index.
+    pub fn state(&self, index: usize) -> Option<&CodebaseState> {
+        self.states.get(index)
+    }
+
+    /// Returns one exported state by its Rust state name.
+    pub fn state_named(&self, rust_name: &str) -> Option<&CodebaseState> {
+        self.states
+            .iter()
+            .find(|state| state.rust_name == rust_name)
+    }
+
+    /// Stable renderer node id for one state in this machine.
+    pub fn node_id(&self, state_index: usize) -> String {
+        format!("m{}_s{}", self.index, state_index)
+    }
+
+    fn cluster_id(&self) -> String {
+        format!("m{}", self.index)
+    }
+
+    fn display_label(&self) -> Cow<'static, str> {
+        match self.label {
+            Some(label) => Cow::Borrowed(label),
+            None => Cow::Borrowed(self.rust_type_path),
+        }
+    }
+}
+
+/// One state in the codebase export surface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseState {
+    /// Stable machine-local state index.
+    pub index: usize,
+    /// Rust variant name emitted by Statum.
+    pub rust_name: &'static str,
+    /// Optional human-facing state label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing state description.
+    pub description: Option<&'static str>,
+    /// Whether the state carries `state_data`.
+    pub has_data: bool,
+    /// Whether the state has no incoming transition in its machine.
+    pub is_root: bool,
+}
+
+impl CodebaseState {
+    /// Human-facing state label used by text renderers.
+    pub fn display_label(&self) -> Cow<'static, str> {
+        match self.label {
+            Some(label) => Cow::Borrowed(label),
+            None if self.has_data => Cow::Owned(format!("{} (data)", self.rust_name)),
+            None => Cow::Borrowed(self.rust_name),
+        }
+    }
+}
+
+/// One transition site in the codebase export surface.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseTransition {
+    /// Stable machine-local transition index.
+    pub index: usize,
+    /// Rust method name emitted by Statum.
+    pub method_name: &'static str,
+    /// Optional human-facing transition label.
+    pub label: Option<&'static str>,
+    /// Optional human-facing transition description.
+    pub description: Option<&'static str>,
+    /// Stable source-state index.
+    pub from: usize,
+    /// Stable legal target-state indices for this transition site.
+    pub to: Vec<usize>,
+}
+
+impl CodebaseTransition {
+    /// Human-facing edge label used by text renderers.
+    pub fn display_label(&self) -> &'static str {
+        self.label.unwrap_or(self.method_name)
+    }
+}
+
+/// One resolved static cross-machine payload link.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct CodebaseLink {
+    /// Stable codebase-local link index.
+    pub index: usize,
+    /// Source machine index.
+    pub from_machine: usize,
+    /// Source state index within `from_machine`.
+    pub from_state: usize,
+    /// Named field for named payloads; `None` for tuple payloads.
+    pub field_name: Option<&'static str>,
+    /// Target machine index.
+    pub to_machine: usize,
+    /// Target state index within `to_machine`.
+    pub to_state: usize,
+}
+
+impl CodebaseLink {
+    /// Human-facing link label used by text renderers.
+    pub fn display_label(&self) -> &'static str {
+        self.field_name.unwrap_or("state_data")
+    }
+}
+
+/// Error returned when a linked machine inventory cannot be exported into a
+/// stable codebase document.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CodebaseDocError {
+    /// One linked machine family appears more than once in the inventory.
+    DuplicateMachine { machine: &'static str },
+    /// One linked machine exports no states.
+    EmptyStateList { machine: &'static str },
+    /// One state name appears more than once in one machine.
+    DuplicateStateName {
+        machine: &'static str,
+        state: &'static str,
+    },
+    /// One source state declares the same transition method name more than once.
+    DuplicateTransitionSite {
+        machine: &'static str,
+        state: &'static str,
+        transition: &'static str,
+    },
+    /// One transition source state is not present in the machine state list.
+    MissingSourceState {
+        machine: &'static str,
+        transition: &'static str,
+    },
+    /// One transition target state is not present in the machine state list.
+    MissingTargetState {
+        machine: &'static str,
+        transition: &'static str,
+    },
+    /// One transition site declares no legal target states.
+    EmptyTargetSet {
+        machine: &'static str,
+        transition: &'static str,
+    },
+    /// One transition lists the same target state more than once.
+    DuplicateTargetState {
+        machine: &'static str,
+        transition: &'static str,
+        state: &'static str,
+    },
+    /// One static payload link points at a source state missing from the
+    /// machine state list.
+    MissingStaticLinkSourceState {
+        machine: &'static str,
+        state: &'static str,
+    },
+    /// One static payload link matches multiple linked machine families.
+    AmbiguousStaticLink {
+        machine: &'static str,
+        state: &'static str,
+        field_name: Option<&'static str>,
+        target_machine_path: String,
+        target_state: &'static str,
+    },
+}
+
+impl core::fmt::Display for CodebaseDocError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DuplicateMachine { machine } => write!(
+                formatter,
+                "linked codebase export cannot merge duplicate machine path `{machine}`. \
+This usually means multiple linked crates define machines at the same crate-local module path. \
+Whole-workspace export treats that path as the machine identity, so the merge would be ambiguous. \
+Fix: rerun with `--package` to export one crate, or move one machine to a distinct module path."
+            ),
+            Self::EmptyStateList { machine } => {
+                write!(formatter, "linked machine `{machine}` contains no states")
+            }
+            Self::DuplicateStateName { machine, state } => write!(
+                formatter,
+                "linked machine `{machine}` contains duplicate state `{state}`"
+            ),
+            Self::DuplicateTransitionSite {
+                machine,
+                state,
+                transition,
+            } => write!(
+                formatter,
+                "linked machine `{machine}` contains duplicate transition site `{state}::{transition}`"
+            ),
+            Self::MissingSourceState { machine, transition } => write!(
+                formatter,
+                "linked machine `{machine}` contains transition `{transition}` whose source state is missing from the state list"
+            ),
+            Self::MissingTargetState { machine, transition } => write!(
+                formatter,
+                "linked machine `{machine}` contains transition `{transition}` whose target state is missing from the state list"
+            ),
+            Self::EmptyTargetSet { machine, transition } => write!(
+                formatter,
+                "linked machine `{machine}` contains transition `{transition}` with no target states"
+            ),
+            Self::DuplicateTargetState {
+                machine,
+                transition,
+                state,
+            } => write!(
+                formatter,
+                "linked machine `{machine}` contains transition `{transition}` with duplicate target state `{state}`"
+            ),
+            Self::MissingStaticLinkSourceState { machine, state } => write!(
+                formatter,
+                "linked machine `{machine}` contains a static payload link from missing source state `{state}`"
+            ),
+            Self::AmbiguousStaticLink {
+                machine,
+                state,
+                field_name,
+                target_machine_path,
+                target_state,
+            } => match field_name {
+                Some(field_name) => write!(
+                    formatter,
+                    "linked machine `{machine}` state `{state}` field `{field_name}` ambiguously matches static target `{target_machine_path}<{target_state}>`"
+                ),
+                None => write!(
+                    formatter,
+                    "linked machine `{machine}` state `{state}` ambiguously matches static target `{target_machine_path}<{target_state}>`"
+                ),
+            },
+        }
+    }
+}
+
+impl std::error::Error for CodebaseDocError {}
+
+fn build_machine(
+    machine_index: usize,
+    linked: LinkedMachineGraph,
+) -> Result<(CodebaseMachine, Vec<&'static StaticMachineLinkDescriptor>), CodebaseDocError> {
+    if linked.states.is_empty() {
+        return Err(CodebaseDocError::EmptyStateList {
+            machine: linked.machine.rust_type_path,
+        });
+    }
+
+    let mut states = Vec::with_capacity(linked.states.len());
+    let mut state_positions = HashMap::with_capacity(linked.states.len());
+    for (index, state) in linked.states.iter().enumerate() {
+        if state_positions.insert(state.rust_name, index).is_some() {
+            return Err(CodebaseDocError::DuplicateStateName {
+                machine: linked.machine.rust_type_path,
+                state: state.rust_name,
+            });
+        }
+
+        states.push(CodebaseState {
+            index,
+            rust_name: state.rust_name,
+            label: state.label,
+            description: state.description,
+            has_data: state.has_data,
+            is_root: true,
+        });
+    }
+
+    let mut transitions = linked.transitions.as_slice().to_vec();
+    transitions.sort_by(|left, right| compare_transitions(&state_positions, left, right));
+
+    let mut exported_transitions = Vec::with_capacity(transitions.len());
+    let mut incoming = HashSet::new();
+    let mut seen_sites = HashSet::with_capacity(transitions.len());
+
+    for (index, transition) in transitions.iter().enumerate() {
+        let Some(&from) = state_positions.get(transition.from) else {
+            return Err(CodebaseDocError::MissingSourceState {
+                machine: linked.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        };
+        if !seen_sites.insert((transition.from, transition.method_name)) {
+            return Err(CodebaseDocError::DuplicateTransitionSite {
+                machine: linked.machine.rust_type_path,
+                state: transition.from,
+                transition: transition.method_name,
+            });
+        }
+        if transition.to.is_empty() {
+            return Err(CodebaseDocError::EmptyTargetSet {
+                machine: linked.machine.rust_type_path,
+                transition: transition.method_name,
+            });
+        }
+
+        let mut to = Vec::with_capacity(transition.to.len());
+        let mut seen_targets = HashSet::with_capacity(transition.to.len());
+        for target in transition.to {
+            let Some(&target_index) = state_positions.get(target) else {
+                return Err(CodebaseDocError::MissingTargetState {
+                    machine: linked.machine.rust_type_path,
+                    transition: transition.method_name,
+                });
+            };
+            if !seen_targets.insert(*target) {
+                return Err(CodebaseDocError::DuplicateTargetState {
+                    machine: linked.machine.rust_type_path,
+                    transition: transition.method_name,
+                    state: target,
+                });
+            }
+            incoming.insert(target_index);
+            to.push(target_index);
+        }
+
+        exported_transitions.push(CodebaseTransition {
+            index,
+            method_name: transition.method_name,
+            label: transition.label,
+            description: transition.description,
+            from,
+            to,
+        });
+    }
+
+    for state in &mut states {
+        state.is_root = !incoming.contains(&state.index);
+    }
+
+    Ok((
+        CodebaseMachine {
+            index: machine_index,
+            module_path: linked.machine.module_path,
+            rust_type_path: linked.machine.rust_type_path,
+            label: linked.label,
+            description: linked.description,
+            states,
+            transitions: exported_transitions,
+        },
+        linked.static_links.iter().collect(),
+    ))
+}
+
+fn compare_transitions(
+    state_positions: &HashMap<&'static str, usize>,
+    left: &statum::LinkedTransitionDescriptor,
+    right: &statum::LinkedTransitionDescriptor,
+) -> core::cmp::Ordering {
+    let left_from = state_positions
+        .get(left.from)
+        .copied()
+        .expect("linked transition source should exist");
+    let right_from = state_positions
+        .get(right.from)
+        .copied()
+        .expect("linked transition source should exist");
+
+    left_from
+        .cmp(&right_from)
+        .then_with(|| left.method_name.cmp(right.method_name))
+        .then_with(|| left.to.cmp(right.to))
+}
+
+fn resolve_static_links(
+    machines: &[CodebaseMachine],
+    static_links: &[Vec<&'static StaticMachineLinkDescriptor>],
+) -> Result<Vec<CodebaseLink>, CodebaseDocError> {
+    let mut links = Vec::new();
+
+    for (machine_index, machine_links) in static_links.iter().enumerate() {
+        let machine = &machines[machine_index];
+        for link in machine_links {
+            let Some(from_state) = machine
+                .state_named(link.from_state)
+                .map(|state| state.index)
+            else {
+                return Err(CodebaseDocError::MissingStaticLinkSourceState {
+                    machine: machine.rust_type_path,
+                    state: link.from_state,
+                });
+            };
+
+            let candidates = machines
+                .iter()
+                .filter_map(|candidate| {
+                    if !path_suffix_matches(candidate.rust_type_path, link.to_machine_path) {
+                        return None;
+                    }
+
+                    candidate
+                        .state_named(link.to_state)
+                        .map(|target_state| (candidate.index, target_state.index))
+                })
+                .collect::<Vec<_>>();
+
+            match candidates.as_slice() {
+                [] => {}
+                [(to_machine, to_state)] => links.push(CodebaseLink {
+                    index: links.len(),
+                    from_machine: machine_index,
+                    from_state,
+                    field_name: link.field_name,
+                    to_machine: *to_machine,
+                    to_state: *to_state,
+                }),
+                _ => {
+                    return Err(CodebaseDocError::AmbiguousStaticLink {
+                        machine: machine.rust_type_path,
+                        state: link.from_state,
+                        field_name: link.field_name,
+                        target_machine_path: link.to_machine_path.join("::"),
+                        target_state: link.to_state,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(links)
+}
+
+fn path_suffix_matches(candidate: &str, suffix: &[&'static str]) -> bool {
+    let candidate = candidate.split("::").collect::<Vec<_>>();
+    candidate.ends_with(suffix)
+}

--- a/statum-graph/src/codebase/render.rs
+++ b/statum-graph/src/codebase/render.rs
@@ -1,0 +1,301 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::codebase::CodebaseDoc;
+
+/// One built-in renderer output format for codebase documents.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Format {
+    Mermaid,
+    Dot,
+    PlantUml,
+    Json,
+}
+
+impl Format {
+    /// All built-in renderer formats in stable bundle order.
+    pub const ALL: [Self; 4] = [Self::Mermaid, Self::Dot, Self::PlantUml, Self::Json];
+
+    /// Conventional file extension for this format.
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Mermaid => "mmd",
+            Self::Dot => "dot",
+            Self::PlantUml => "puml",
+            Self::Json => "json",
+        }
+    }
+
+    /// Renders one codebase document into this format.
+    pub fn render(self, doc: &CodebaseDoc) -> String {
+        match self {
+            Self::Mermaid => mermaid(doc),
+            Self::Dot => dot(doc),
+            Self::PlantUml => plantuml(doc),
+            Self::Json => json(doc),
+        }
+    }
+
+    /// Renders one codebase document and writes it to one filesystem path.
+    pub fn write_to<P>(self, doc: &CodebaseDoc, path: P) -> io::Result<PathBuf>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        ensure_parent_dir(path)?;
+        fs::write(path, self.render(doc))?;
+        Ok(path.to_path_buf())
+    }
+}
+
+/// Renders one codebase document into every built-in format and writes the
+/// resulting files into `dir` using `stem` plus the format extension.
+pub fn write_all_to_dir<P>(doc: &CodebaseDoc, dir: P, stem: &str) -> io::Result<Vec<PathBuf>>
+where
+    P: AsRef<Path>,
+{
+    let dir = dir.as_ref();
+    fs::create_dir_all(dir)?;
+
+    Format::ALL
+        .into_iter()
+        .map(|format| format.write_to(doc, dir.join(format!("{stem}.{}", format.extension()))))
+        .collect()
+}
+
+/// Renders a combined linked-machine topology as Mermaid flowchart text.
+pub fn mermaid(doc: &CodebaseDoc) -> String {
+    let mut lines = vec![
+        format!("%% linked machines: {}", doc.machines().len()),
+        "graph TD".to_string(),
+    ];
+
+    for machine in doc.machines() {
+        lines.push(format!(
+            "    subgraph {}[\"{}\"]",
+            machine.cluster_id(),
+            escape_mermaid_label(&machine.display_label())
+        ));
+        for state in &machine.states {
+            lines.push(format!(
+                "        {}[\"{}\"]",
+                machine.node_id(state.index),
+                escape_mermaid_label(&state.display_label())
+            ));
+        }
+        lines.push("    end".to_string());
+    }
+
+    if !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for transition in &machine.transitions {
+            let from = machine.node_id(transition.from);
+            for target in &transition.to {
+                let to = machine.node_id(*target);
+                lines.push(format!(
+                    "    {from} -->|{}| {to}",
+                    escape_mermaid_edge_label(transition.display_label())
+                ));
+            }
+        }
+    }
+
+    if !doc.links().is_empty() && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for link in doc.links() {
+        let from_machine = doc
+            .machine(link.from_machine)
+            .expect("codebase link source machine should exist");
+        let to_machine = doc
+            .machine(link.to_machine)
+            .expect("codebase link target machine should exist");
+        lines.push(format!(
+            "    {} -.->|{}| {}",
+            from_machine.node_id(link.from_state),
+            escape_mermaid_edge_label(link.display_label()),
+            to_machine.node_id(link.to_state)
+        ));
+    }
+
+    lines.join("\n")
+}
+
+/// Renders a combined linked-machine topology as DOT text.
+pub fn dot(doc: &CodebaseDoc) -> String {
+    let mut lines = vec![
+        "digraph \"statum_codebase\" {".to_string(),
+        "    rankdir=TB;".to_string(),
+    ];
+
+    for machine in doc.machines() {
+        lines.push(format!(
+            "    subgraph \"cluster_{}\" {{",
+            machine.cluster_id()
+        ));
+        lines.push(format!(
+            "        label=\"{}\";",
+            escape_dot_label(&machine.display_label())
+        ));
+        for state in &machine.states {
+            lines.push(format!(
+                "        {} [label=\"{}\"]",
+                machine.node_id(state.index),
+                escape_dot_label(&state.display_label())
+            ));
+        }
+        lines.push("    }".to_string());
+    }
+
+    if !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for transition in &machine.transitions {
+            let from = machine.node_id(transition.from);
+            for target in &transition.to {
+                let to = machine.node_id(*target);
+                lines.push(format!(
+                    "    {from} -> {to} [label=\"{}\"]",
+                    escape_dot_label(transition.display_label())
+                ));
+            }
+        }
+    }
+
+    if !doc.links().is_empty() && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for link in doc.links() {
+        let from_machine = doc
+            .machine(link.from_machine)
+            .expect("codebase link source machine should exist");
+        let to_machine = doc
+            .machine(link.to_machine)
+            .expect("codebase link target machine should exist");
+        lines.push(format!(
+            "    {} -> {} [style=dashed, label=\"{}\"]",
+            from_machine.node_id(link.from_state),
+            to_machine.node_id(link.to_state),
+            escape_dot_label(link.display_label())
+        ));
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
+}
+
+/// Renders a combined linked-machine topology as PlantUML state text.
+pub fn plantuml(doc: &CodebaseDoc) -> String {
+    let mut lines = vec![
+        "@startuml".to_string(),
+        format!("' linked machines: {}", doc.machines().len()),
+    ];
+
+    for machine in doc.machines() {
+        lines.push(format!(
+            "state \"{}\" as {} {{",
+            escape_plantuml_label(&machine.display_label()),
+            machine.cluster_id()
+        ));
+        for state in &machine.states {
+            lines.push(format!(
+                "    state \"{}\" as {}",
+                escape_plantuml_label(&state.display_label()),
+                machine.node_id(state.index)
+            ));
+        }
+        lines.push("}".to_string());
+    }
+
+    if !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for transition in &machine.transitions {
+            let from = machine.node_id(transition.from);
+            for target in &transition.to {
+                let to = machine.node_id(*target);
+                lines.push(format!(
+                    "{from} --> {to} : {}",
+                    escape_plantuml_label(transition.display_label())
+                ));
+            }
+        }
+    }
+
+    if !doc.links().is_empty() && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for link in doc.links() {
+        let from_machine = doc
+            .machine(link.from_machine)
+            .expect("codebase link source machine should exist");
+        let to_machine = doc
+            .machine(link.to_machine)
+            .expect("codebase link target machine should exist");
+        lines.push(format!(
+            "{} ..> {} : {}",
+            from_machine.node_id(link.from_state),
+            to_machine.node_id(link.to_state),
+            escape_plantuml_label(link.display_label())
+        ));
+    }
+
+    lines.push("@enduml".to_string());
+    lines.join("\n")
+}
+
+/// Renders a combined linked-machine topology as deterministic pretty JSON.
+pub fn json(doc: &CodebaseDoc) -> String {
+    serde_json::to_string_pretty(doc).expect("CodebaseDoc serialization should not fail")
+}
+
+fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent().filter(|path| !path.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+fn escape_mermaid_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn escape_mermaid_edge_label(label: &str) -> String {
+    label
+        .replace('&', "&amp;")
+        .replace('|', "&#124;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace('\n', "<br/>")
+}
+
+fn escape_dot_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn escape_plantuml_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}

--- a/statum-graph/src/codebase/render.rs
+++ b/statum-graph/src/codebase/render.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::codebase::CodebaseDoc;
+use crate::render::{bundle_output_path, validate_output_stem};
 
 /// One built-in renderer output format for codebase documents.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -56,11 +57,15 @@ where
     P: AsRef<Path>,
 {
     let dir = dir.as_ref();
+    validate_output_stem(stem)?;
     fs::create_dir_all(dir)?;
 
     Format::ALL
         .into_iter()
-        .map(|format| format.write_to(doc, dir.join(format!("{stem}.{}", format.extension()))))
+        .map(|format| {
+            bundle_output_path(dir, stem, format.extension())
+                .and_then(|path| format.write_to(doc, path))
+        })
         .collect()
 }
 

--- a/statum-graph/src/codebase/render.rs
+++ b/statum-graph/src/codebase/render.rs
@@ -70,6 +70,10 @@ pub fn mermaid(doc: &CodebaseDoc) -> String {
         format!("%% linked machines: {}", doc.machines().len()),
         "graph TD".to_string(),
     ];
+    let has_validator_entries = doc
+        .machines()
+        .iter()
+        .any(|machine| !machine.validator_entries.is_empty());
 
     for machine in doc.machines() {
         lines.push(format!(
@@ -87,7 +91,21 @@ pub fn mermaid(doc: &CodebaseDoc) -> String {
         lines.push("    end".to_string());
     }
 
-    if !doc.machines().is_empty() {
+    if has_validator_entries && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            lines.push(format!(
+                "    {}(\"{}\")",
+                machine.validator_node_id(entry.index),
+                escape_mermaid_label(&entry.display_label())
+            ));
+        }
+    }
+
+    if !doc.machines().is_empty() && (has_validator_entries || any_transitions(doc)) {
         lines.push(String::new());
     }
 
@@ -123,6 +141,21 @@ pub fn mermaid(doc: &CodebaseDoc) -> String {
         ));
     }
 
+    if has_validator_entries
+        && (!doc.links().is_empty() || any_transitions(doc) || !doc.machines().is_empty())
+    {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            let from = machine.validator_node_id(entry.index);
+            for target in &entry.target_states {
+                lines.push(format!("    {from} -.-> {}", machine.node_id(*target)));
+            }
+        }
+    }
+
     lines.join("\n")
 }
 
@@ -132,6 +165,10 @@ pub fn dot(doc: &CodebaseDoc) -> String {
         "digraph \"statum_codebase\" {".to_string(),
         "    rankdir=TB;".to_string(),
     ];
+    let has_validator_entries = doc
+        .machines()
+        .iter()
+        .any(|machine| !machine.validator_entries.is_empty());
 
     for machine in doc.machines() {
         lines.push(format!(
@@ -152,7 +189,21 @@ pub fn dot(doc: &CodebaseDoc) -> String {
         lines.push("    }".to_string());
     }
 
-    if !doc.machines().is_empty() {
+    if has_validator_entries && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            lines.push(format!(
+                "    {} [label=\"{}\", shape=ellipse, style=\"rounded,dashed\", color=\"#4b5563\"]",
+                machine.validator_node_id(entry.index),
+                escape_dot_label(&entry.display_label())
+            ));
+        }
+    }
+
+    if !doc.machines().is_empty() && (has_validator_entries || any_transitions(doc)) {
         lines.push(String::new());
     }
 
@@ -188,6 +239,24 @@ pub fn dot(doc: &CodebaseDoc) -> String {
         ));
     }
 
+    if has_validator_entries
+        && (!doc.links().is_empty() || any_transitions(doc) || !doc.machines().is_empty())
+    {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            let from = machine.validator_node_id(entry.index);
+            for target in &entry.target_states {
+                lines.push(format!(
+                    "    {from} -> {} [style=dashed, color=\"#4b5563\", penwidth=2, constraint=false]",
+                    machine.node_id(*target)
+                ));
+            }
+        }
+    }
+
     lines.push("}".to_string());
     lines.join("\n")
 }
@@ -198,6 +267,10 @@ pub fn plantuml(doc: &CodebaseDoc) -> String {
         "@startuml".to_string(),
         format!("' linked machines: {}", doc.machines().len()),
     ];
+    let has_validator_entries = doc
+        .machines()
+        .iter()
+        .any(|machine| !machine.validator_entries.is_empty());
 
     for machine in doc.machines() {
         lines.push(format!(
@@ -215,7 +288,21 @@ pub fn plantuml(doc: &CodebaseDoc) -> String {
         lines.push("}".to_string());
     }
 
-    if !doc.machines().is_empty() {
+    if has_validator_entries && !doc.machines().is_empty() {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            lines.push(format!(
+                "state \"{}\" as {} <<validator-entry>>",
+                escape_plantuml_label(&entry.display_label()),
+                machine.validator_node_id(entry.index)
+            ));
+        }
+    }
+
+    if !doc.machines().is_empty() && (has_validator_entries || any_transitions(doc)) {
         lines.push(String::new());
     }
 
@@ -251,6 +338,24 @@ pub fn plantuml(doc: &CodebaseDoc) -> String {
         ));
     }
 
+    if has_validator_entries
+        && (!doc.links().is_empty() || any_transitions(doc) || !doc.machines().is_empty())
+    {
+        lines.push(String::new());
+    }
+
+    for machine in doc.machines() {
+        for entry in &machine.validator_entries {
+            let from = machine.validator_node_id(entry.index);
+            for target in &entry.target_states {
+                lines.push(format!(
+                    "{from} ..> {} : validator entry",
+                    machine.node_id(*target)
+                ));
+            }
+        }
+    }
+
     lines.push("@enduml".to_string());
     lines.join("\n")
 }
@@ -266,6 +371,12 @@ fn ensure_parent_dir(path: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+fn any_transitions(doc: &CodebaseDoc) -> bool {
+    doc.machines()
+        .iter()
+        .any(|machine| !machine.transitions.is_empty())
 }
 
 fn escape_mermaid_label(label: &str) -> String {

--- a/statum-graph/src/export.rs
+++ b/statum-graph/src/export.rs
@@ -271,6 +271,7 @@ where
             export.machine.description = machine.description;
         }
 
+        let mut seen_states = vec![false; export.states.len()];
         for (entry, presented_state) in presentation.states.iter().enumerate() {
             let Some(index) = self
                 .states()
@@ -283,18 +284,19 @@ where
                 });
             };
 
-            let export_state = &mut export.states[index];
-            if export_state.label.is_some() || export_state.description.is_some() {
+            if std::mem::replace(&mut seen_states[index], true) {
                 return Err(ExportDocError::DuplicateStatePresentation {
                     machine: self.machine().rust_type_path,
                     entry,
                 });
             }
 
+            let export_state = &mut export.states[index];
             export_state.label = presented_state.label;
             export_state.description = presented_state.description;
         }
 
+        let mut seen_transitions = vec![false; export.transitions.len()];
         for (entry, presented_transition) in presentation.transitions.iter().enumerate() {
             let Some(index) = self
                 .edges()
@@ -307,14 +309,14 @@ where
                 });
             };
 
-            let export_transition = &mut export.transitions[index];
-            if export_transition.label.is_some() || export_transition.description.is_some() {
+            if std::mem::replace(&mut seen_transitions[index], true) {
                 return Err(ExportDocError::DuplicateTransitionPresentation {
                     machine: self.machine().rust_type_path,
                     entry,
                 });
             }
 
+            let export_transition = &mut export.transitions[index];
             export_transition.label = presented_transition.label;
             export_transition.description = presented_transition.description;
         }

--- a/statum-graph/src/export.rs
+++ b/statum-graph/src/export.rs
@@ -1,0 +1,324 @@
+use std::borrow::Cow;
+
+use serde::Serialize;
+use statum::MachinePresentation;
+
+use crate::MachineDoc;
+
+/// Stable export model for one validated machine graph.
+///
+/// This type is the canonical renderer input for Mermaid, DOT, PlantUML, and
+/// JSON output. Structure comes from [`statum::MachineIntrospection::GRAPH`];
+/// labels and descriptions may be joined from a matching
+/// [`statum::MachinePresentation`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExportDoc {
+    /// Exported machine metadata.
+    machine: ExportMachine,
+    /// Exported states in stable graph order.
+    states: Vec<ExportState>,
+    /// Exported transition sites in stable graph order.
+    transitions: Vec<ExportTransition>,
+}
+
+impl ExportDoc {
+    /// Exported machine metadata.
+    pub fn machine(&self) -> ExportMachine {
+        self.machine
+    }
+
+    /// Exported states in stable graph order.
+    pub fn states(&self) -> &[ExportState] {
+        &self.states
+    }
+
+    /// Exported transition sites in stable graph order.
+    pub fn transitions(&self) -> &[ExportTransition] {
+        &self.transitions
+    }
+
+    /// Returns one exported state by its stable state index.
+    pub fn state(&self, index: usize) -> Option<&ExportState> {
+        self.states.get(index)
+    }
+
+    /// Returns one exported transition site by its stable transition index.
+    pub fn transition(&self, index: usize) -> Option<&ExportTransition> {
+        self.transitions.get(index)
+    }
+}
+
+/// Machine metadata preserved in the stable export surface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ExportMachine {
+    /// `module_path!()` for the source module that owns the machine.
+    pub module_path: &'static str,
+    /// Fully qualified Rust type path for the machine family.
+    pub rust_type_path: &'static str,
+    /// Optional human-facing label from presentation metadata.
+    pub label: Option<&'static str>,
+    /// Optional human-facing description from presentation metadata.
+    pub description: Option<&'static str>,
+}
+
+/// State metadata preserved in the stable export surface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ExportState {
+    /// Stable export-local state index.
+    pub index: usize,
+    /// Rust variant name emitted by Statum.
+    pub rust_name: &'static str,
+    /// Optional human-facing label from presentation metadata.
+    pub label: Option<&'static str>,
+    /// Optional human-facing description from presentation metadata.
+    pub description: Option<&'static str>,
+    /// Whether the state carries `state_data`.
+    pub has_data: bool,
+    /// Whether the state has no incoming edge in the exported topology.
+    pub is_root: bool,
+}
+
+impl ExportState {
+    /// Stable renderer node id for this state.
+    pub fn node_id(&self) -> String {
+        format!("s{}", self.index)
+    }
+
+    /// Human-facing state label used by text renderers.
+    pub fn display_label(&self) -> Cow<'static, str> {
+        match self.label {
+            Some(label) => Cow::Borrowed(label),
+            None if self.has_data => Cow::Owned(format!("{} (data)", self.rust_name)),
+            None => Cow::Borrowed(self.rust_name),
+        }
+    }
+}
+
+/// Transition-site metadata preserved in the stable export surface.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ExportTransition {
+    /// Stable export-local transition index.
+    pub index: usize,
+    /// Rust method name emitted by Statum.
+    pub method_name: &'static str,
+    /// Optional human-facing label from presentation metadata.
+    pub label: Option<&'static str>,
+    /// Optional human-facing description from presentation metadata.
+    pub description: Option<&'static str>,
+    /// Stable source-state index.
+    pub from: usize,
+    /// Stable legal target-state indices for this transition site.
+    pub to: Vec<usize>,
+}
+
+impl ExportTransition {
+    /// Stable renderer transition id for this transition site.
+    pub fn transition_id(&self) -> String {
+        format!("t{}", self.index)
+    }
+
+    /// Human-facing edge label used by text renderers.
+    pub fn display_label(&self) -> &'static str {
+        self.label.unwrap_or(self.method_name)
+    }
+}
+
+/// Error returned when presentation metadata cannot be joined onto a
+/// validated machine graph.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExportDocError {
+    /// One state presentation entry points at a state id that is not in the
+    /// validated graph.
+    UnknownStatePresentation { machine: &'static str, entry: usize },
+    /// One state id appears more than once in the presentation overlay.
+    DuplicateStatePresentation { machine: &'static str, entry: usize },
+    /// One transition presentation entry points at a transition id that is not
+    /// in the validated graph.
+    UnknownTransitionPresentation { machine: &'static str, entry: usize },
+    /// One transition id appears more than once in the presentation overlay.
+    DuplicateTransitionPresentation { machine: &'static str, entry: usize },
+}
+
+impl core::fmt::Display for ExportDocError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnknownStatePresentation { machine, entry } => write!(
+                formatter,
+                "presentation for machine `{machine}` contains state entry {} whose id is missing from the graph",
+                entry + 1
+            ),
+            Self::DuplicateStatePresentation { machine, entry } => write!(
+                formatter,
+                "presentation for machine `{machine}` contains duplicate state id at entry {}",
+                entry + 1
+            ),
+            Self::UnknownTransitionPresentation { machine, entry } => write!(
+                formatter,
+                "presentation for machine `{machine}` contains transition entry {} whose id is missing from the graph",
+                entry + 1
+            ),
+            Self::DuplicateTransitionPresentation { machine, entry } => write!(
+                formatter,
+                "presentation for machine `{machine}` contains duplicate transition id at entry {}",
+                entry + 1
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExportDocError {}
+
+impl<S, T> From<&MachineDoc<S, T>> for ExportDoc
+where
+    S: Eq,
+{
+    fn from(doc: &MachineDoc<S, T>) -> Self {
+        Self {
+            machine: ExportMachine {
+                module_path: doc.machine().module_path,
+                rust_type_path: doc.machine().rust_type_path,
+                label: None,
+                description: None,
+            },
+            states: doc
+                .states()
+                .iter()
+                .enumerate()
+                .map(|(index, state)| ExportState {
+                    index,
+                    rust_name: state.descriptor.rust_name,
+                    label: None,
+                    description: None,
+                    has_data: state.descriptor.has_data,
+                    is_root: state.is_root,
+                })
+                .collect(),
+            transitions: doc
+                .edges()
+                .iter()
+                .enumerate()
+                .map(|(index, edge)| ExportTransition {
+                    index,
+                    method_name: edge.descriptor.method_name,
+                    label: None,
+                    description: None,
+                    from: doc
+                        .states()
+                        .iter()
+                        .position(|state| state.descriptor.id == edge.descriptor.from)
+                        .expect("MachineDoc state ids should align with edges"),
+                    to: edge
+                        .descriptor
+                        .to
+                        .iter()
+                        .map(|target| {
+                            doc.states()
+                                .iter()
+                                .position(|state| state.descriptor.id == *target)
+                                .expect("MachineDoc target ids should align with states")
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+pub trait ExportSource {
+    fn export_doc(&self) -> Cow<'_, ExportDoc>;
+}
+
+impl ExportSource for ExportDoc {
+    fn export_doc(&self) -> Cow<'_, ExportDoc> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl<S, T> ExportSource for MachineDoc<S, T>
+where
+    S: Eq,
+{
+    fn export_doc(&self) -> Cow<'_, ExportDoc> {
+        Cow::Owned(self.export())
+    }
+}
+
+impl<S, T> MachineDoc<S, T>
+where
+    S: Eq,
+{
+    /// Builds the canonical stable export model without presentation metadata.
+    pub fn export(&self) -> ExportDoc {
+        ExportDoc::from(self)
+    }
+}
+
+impl<S, T> MachineDoc<S, T>
+where
+    S: Copy + Eq + 'static,
+    T: Copy + Eq + 'static,
+{
+    /// Builds the canonical stable export model and joins matching labels and
+    /// descriptions from a presentation overlay.
+    pub fn export_with_presentation<MachineMeta, StateMeta, TransitionMeta>(
+        &self,
+        presentation: &MachinePresentation<S, T, MachineMeta, StateMeta, TransitionMeta>,
+    ) -> Result<ExportDoc, ExportDocError> {
+        let mut export = self.export();
+
+        if let Some(machine) = &presentation.machine {
+            export.machine.label = machine.label;
+            export.machine.description = machine.description;
+        }
+
+        for (entry, presented_state) in presentation.states.iter().enumerate() {
+            let Some(index) = self
+                .states()
+                .iter()
+                .position(|state| state.descriptor.id == presented_state.id)
+            else {
+                return Err(ExportDocError::UnknownStatePresentation {
+                    machine: self.machine().rust_type_path,
+                    entry,
+                });
+            };
+
+            let export_state = &mut export.states[index];
+            if export_state.label.is_some() || export_state.description.is_some() {
+                return Err(ExportDocError::DuplicateStatePresentation {
+                    machine: self.machine().rust_type_path,
+                    entry,
+                });
+            }
+
+            export_state.label = presented_state.label;
+            export_state.description = presented_state.description;
+        }
+
+        for (entry, presented_transition) in presentation.transitions.iter().enumerate() {
+            let Some(index) = self
+                .edges()
+                .iter()
+                .position(|edge| edge.descriptor.id == presented_transition.id)
+            else {
+                return Err(ExportDocError::UnknownTransitionPresentation {
+                    machine: self.machine().rust_type_path,
+                    entry,
+                });
+            };
+
+            let export_transition = &mut export.transitions[index];
+            if export_transition.label.is_some() || export_transition.description.is_some() {
+                return Err(ExportDocError::DuplicateTransitionPresentation {
+                    machine: self.machine().rust_type_path,
+                    entry,
+                });
+            }
+
+            export_transition.label = presented_transition.label;
+            export_transition.description = presented_transition.description;
+        }
+
+        Ok(export)
+    }
+}

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -2,12 +2,15 @@
 //!
 //! This crate is authoritative only for machine-local topology:
 //! machine identity, states, transition sites, exact legal targets, and
-//! roots derivable from the static graph itself.
+//! graph roots derivable from the static graph itself.
 //!
 //! For linked-build codebase export, use [`codebase::CodebaseDoc`]. That
-//! surface combines every linked compiled machine family plus statically
-//! written direct machine-like payload links that can be resolved without
-//! runtime execution.
+//! surface combines every linked compiled machine family, statically written
+//! direct machine-like payload links, and declared validator-entry surfaces
+//! emitted by compiled `#[validators]` impls. Validator node labels use the
+//! impl self type as written in source, so they are display syntax rather than
+//! canonical Rust type identity. Method-level `#[cfg]` and `#[cfg_attr]` on
+//! validator methods are rejected at the macro layer.
 //!
 //! Use [`MachineDoc::from_machine`] for Statum-generated machine families and
 //! [`MachineDoc::try_from_graph`] when you need to validate an externally
@@ -29,7 +32,8 @@ mod export;
 pub mod render;
 
 pub use codebase::{
-    CodebaseDoc, CodebaseDocError, CodebaseLink, CodebaseMachine, CodebaseState, CodebaseTransition,
+    CodebaseDoc, CodebaseDocError, CodebaseLink, CodebaseMachine, CodebaseState,
+    CodebaseTransition, CodebaseValidatorEntry,
 };
 pub use export::{
     ExportDoc, ExportDocError, ExportMachine, ExportSource, ExportState, ExportTransition,
@@ -38,7 +42,7 @@ pub use export::{
 /// Static machine graph exported directly from `MachineIntrospection::GRAPH`.
 ///
 /// This type is authoritative only for machine-local topology:
-/// states, transition sites, exact legal targets, and roots derivable
+/// states, transition sites, exact legal targets, and graph roots derivable
 /// from the static graph itself.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MachineDoc<S: 'static, T: 'static> {

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -4,13 +4,19 @@
 //! machine identity, states, transition sites, exact legal targets, and
 //! roots derivable from the static graph itself.
 //!
+//! For linked-build codebase export, use [`codebase::CodebaseDoc`]. That
+//! surface combines every linked compiled machine family plus statically
+//! written direct machine-like payload links that can be resolved without
+//! runtime execution.
+//!
 //! Use [`MachineDoc::from_machine`] for Statum-generated machine families and
 //! [`MachineDoc::try_from_graph`] when you need to validate an externally
 //! supplied [`MachineGraph`] before rendering or traversal.
 //!
-//! This crate does not model orchestration order across machines,
-//! runtime-selected branches for one run, or any consumer-owned presentation
-//! metadata.
+//! This crate does not model orchestration order across machines or
+//! runtime-selected branches for one run. Optional presentation metadata may
+//! be joined onto the validated machine graph for renderer output, but it does
+//! not change the authoritative structural surface.
 
 use std::collections::{HashMap, HashSet};
 
@@ -18,7 +24,16 @@ use statum::{
     MachineDescriptor, MachineGraph, MachineIntrospection, StateDescriptor, TransitionDescriptor,
 };
 
+pub mod codebase;
+mod export;
 pub mod render;
+
+pub use codebase::{
+    CodebaseDoc, CodebaseDocError, CodebaseLink, CodebaseMachine, CodebaseState, CodebaseTransition,
+};
+pub use export::{
+    ExportDoc, ExportDocError, ExportMachine, ExportSource, ExportState, ExportTransition,
+};
 
 /// Static machine graph exported directly from `MachineIntrospection::GRAPH`.
 ///

--- a/statum-graph/src/lib.rs
+++ b/statum-graph/src/lib.rs
@@ -10,7 +10,8 @@
 //! emitted by compiled `#[validators]` impls. Validator node labels use the
 //! impl self type as written in source, so they are display syntax rather than
 //! canonical Rust type identity. Method-level `#[cfg]` and `#[cfg_attr]` on
-//! validator methods are rejected at the macro layer.
+//! validator methods are rejected at the macro layer. `include!()`-generated
+//! validator impls are also rejected.
 //!
 //! Use [`MachineDoc::from_machine`] for Statum-generated machine families and
 //! [`MachineDoc::try_from_graph`] when you need to validate an externally

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -63,11 +63,15 @@ where
     P: AsRef<Path>,
 {
     let dir = dir.as_ref();
+    validate_output_stem(stem)?;
     fs::create_dir_all(dir)?;
 
     Format::ALL
         .into_iter()
-        .map(|format| format.write_to(doc, dir.join(format!("{stem}.{}", format.extension()))))
+        .map(|format| {
+            bundle_output_path(dir, stem, format.extension())
+                .and_then(|path| format.write_to(doc, path))
+        })
         .collect()
 }
 
@@ -227,6 +231,24 @@ fn ensure_parent_dir(path: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+pub(crate) fn bundle_output_path(dir: &Path, stem: &str, extension: &str) -> io::Result<PathBuf> {
+    validate_output_stem(stem)?;
+    Ok(dir.join(format!("{stem}.{extension}")))
+}
+
+pub(crate) fn validate_output_stem(stem: &str) -> io::Result<()> {
+    let mut components = Path::new(stem).components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(_)), None) => Ok(()),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "invalid output stem `{stem}`: expected a simple file name without path separators"
+            ),
+        )),
+    }
 }
 
 fn push_comment_lines(lines: &mut Vec<String>, prefix: &str, doc: &ExportDoc) {

--- a/statum-graph/src/render.rs
+++ b/statum-graph/src/render.rs
@@ -1,47 +1,117 @@
-use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
-use crate::MachineDoc;
+use crate::{ExportDoc, ExportSource};
+
+/// One built-in renderer output format.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Format {
+    Mermaid,
+    Dot,
+    PlantUml,
+    Json,
+}
+
+impl Format {
+    /// All built-in renderer formats in stable bundle order.
+    pub const ALL: [Self; 4] = [Self::Mermaid, Self::Dot, Self::PlantUml, Self::Json];
+
+    /// Conventional file extension for this format.
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Mermaid => "mmd",
+            Self::Dot => "dot",
+            Self::PlantUml => "puml",
+            Self::Json => "json",
+        }
+    }
+
+    /// Renders one document into this format.
+    pub fn render<D>(self, doc: &D) -> String
+    where
+        D: ExportSource + ?Sized,
+    {
+        match self {
+            Self::Mermaid => mermaid(doc),
+            Self::Dot => dot(doc),
+            Self::PlantUml => plantuml(doc),
+            Self::Json => json(doc),
+        }
+    }
+
+    /// Renders one document and writes it to one filesystem path.
+    ///
+    /// Parent directories are created when needed.
+    pub fn write_to<D, P>(self, doc: &D, path: P) -> io::Result<PathBuf>
+    where
+        D: ExportSource + ?Sized,
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        ensure_parent_dir(path)?;
+        fs::write(path, self.render(doc))?;
+        Ok(path.to_path_buf())
+    }
+}
+
+/// Renders one document into every built-in format and writes the resulting
+/// files into `dir` using `stem` plus the format extension.
+pub fn write_all_to_dir<D, P>(doc: &D, dir: P, stem: &str) -> io::Result<Vec<PathBuf>>
+where
+    D: ExportSource + ?Sized,
+    P: AsRef<Path>,
+{
+    let dir = dir.as_ref();
+    fs::create_dir_all(dir)?;
+
+    Format::ALL
+        .into_iter()
+        .map(|format| format.write_to(doc, dir.join(format!("{stem}.{}", format.extension()))))
+        .collect()
+}
 
 /// Renders a validated machine-local topology as Mermaid flowchart text.
 ///
-/// Output ordering is deterministic for one [`MachineDoc`]. State labels and
-/// edge labels are escaped for Mermaid so the returned string is suitable for
-/// snapshot tests, generated docs, and CLI output.
-pub fn mermaid<S, T>(doc: &MachineDoc<S, T>) -> String
+/// Output ordering is deterministic for one validated export surface. State
+/// labels and edge labels are escaped for Mermaid so the returned string is
+/// suitable for snapshot tests, generated docs, and CLI output.
+pub fn mermaid<D>(doc: &D) -> String
 where
-    S: Copy + Eq + std::hash::Hash + 'static,
-    T: 'static,
+    D: ExportSource + ?Sized,
 {
-    let state_positions: HashMap<S, usize> = doc
-        .states()
-        .iter()
-        .enumerate()
-        .map(|(index, state)| (state.descriptor.id, index))
-        .collect();
+    let doc = doc.export_doc();
+    let doc = doc.as_ref();
 
-    let mut lines = vec!["graph TD".to_string()];
-    for (index, state) in doc.states().iter().enumerate() {
+    let mut lines = Vec::new();
+    push_comment_lines(&mut lines, "%%", doc);
+    lines.push("graph TD".to_string());
+
+    for state in doc.states() {
         lines.push(format!(
             "    {}[\"{}\"]",
-            node_id(index),
-            escape_label(&state_label(
-                state.descriptor.rust_name,
-                state.descriptor.has_data
-            ))
+            state.node_id(),
+            escape_mermaid_label(&state.display_label())
         ));
     }
 
-    if !doc.edges().is_empty() {
+    if !doc.transitions().is_empty() {
         lines.push(String::new());
     }
 
-    for edge in doc.edges() {
-        let from = node_id(state_positions[&edge.descriptor.from]);
-        for target in edge.descriptor.to {
-            let to = node_id(state_positions[target]);
+    for transition in doc.transitions() {
+        let from = doc
+            .state(transition.from)
+            .expect("ExportDoc transition source should exist")
+            .node_id();
+        for target in &transition.to {
+            let to = doc
+                .state(*target)
+                .expect("ExportDoc transition target should exist")
+                .node_id();
             lines.push(format!(
                 "    {from} -->|{}| {to}",
-                escape_edge_label(edge.descriptor.method_name)
+                escape_mermaid_edge_label(transition.display_label())
             ));
         }
     }
@@ -49,26 +119,138 @@ where
     lines.join("\n")
 }
 
-fn node_id(index: usize) -> String {
-    format!("s{index}")
+/// Renders a validated machine-local topology as DOT text.
+pub fn dot<D>(doc: &D) -> String
+where
+    D: ExportSource + ?Sized,
+{
+    let doc = doc.export_doc();
+    let doc = doc.as_ref();
+
+    let mut lines = Vec::new();
+    push_comment_lines(&mut lines, "//", doc);
+    lines.push(format!(
+        "digraph \"{}\" {{",
+        escape_dot_label(doc.machine().rust_type_path)
+    ));
+    lines.push("    rankdir=TB;".to_string());
+
+    for state in doc.states() {
+        lines.push(format!(
+            "    {} [label=\"{}\"]",
+            state.node_id(),
+            escape_dot_label(&state.display_label())
+        ));
+    }
+
+    if !doc.transitions().is_empty() {
+        lines.push(String::new());
+    }
+
+    for transition in doc.transitions() {
+        let from = doc
+            .state(transition.from)
+            .expect("ExportDoc transition source should exist")
+            .node_id();
+        for target in &transition.to {
+            let to = doc
+                .state(*target)
+                .expect("ExportDoc transition target should exist")
+                .node_id();
+            lines.push(format!(
+                "    {from} -> {to} [label=\"{}\"]",
+                escape_dot_label(transition.display_label())
+            ));
+        }
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
 }
 
-fn state_label(rust_name: &str, has_data: bool) -> String {
-    if has_data {
-        format!("{rust_name} (data)")
-    } else {
-        rust_name.to_string()
+/// Renders a validated machine-local topology as PlantUML state text.
+pub fn plantuml<D>(doc: &D) -> String
+where
+    D: ExportSource + ?Sized,
+{
+    let doc = doc.export_doc();
+    let doc = doc.as_ref();
+
+    let mut lines = vec!["@startuml".to_string()];
+    push_comment_lines(&mut lines, "'", doc);
+
+    for state in doc.states() {
+        lines.push(format!(
+            "state \"{}\" as {}",
+            escape_plantuml_label(&state.display_label()),
+            state.node_id()
+        ));
+    }
+
+    if !doc.transitions().is_empty() {
+        lines.push(String::new());
+    }
+
+    for transition in doc.transitions() {
+        let from = doc
+            .state(transition.from)
+            .expect("ExportDoc transition source should exist")
+            .node_id();
+        for target in &transition.to {
+            let to = doc
+                .state(*target)
+                .expect("ExportDoc transition target should exist")
+                .node_id();
+            lines.push(format!(
+                "{from} --> {to} : {}",
+                escape_plantuml_label(transition.display_label())
+            ));
+        }
+    }
+
+    lines.push("@enduml".to_string());
+    lines.join("\n")
+}
+
+/// Renders a validated machine-local topology as deterministic pretty JSON.
+pub fn json<D>(doc: &D) -> String
+where
+    D: ExportSource + ?Sized,
+{
+    let doc = doc.export_doc();
+    serde_json::to_string_pretty(doc.as_ref()).expect("ExportDoc serialization should not fail")
+}
+
+fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent().filter(|path| !path.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+fn push_comment_lines(lines: &mut Vec<String>, prefix: &str, doc: &ExportDoc) {
+    if let Some(label) = doc.machine().label {
+        for line in label.lines() {
+            lines.push(format!("{prefix} {line}"));
+        }
+    }
+
+    if let Some(description) = doc.machine().description {
+        for line in description.lines() {
+            lines.push(format!("{prefix} {line}"));
+        }
     }
 }
 
-fn escape_label(label: &str) -> String {
+fn escape_mermaid_label(label: &str) -> String {
     label
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\n")
 }
 
-fn escape_edge_label(label: &str) -> String {
+fn escape_mermaid_edge_label(label: &str) -> String {
     label
         .replace('&', "&amp;")
         .replace('|', "&#124;")
@@ -77,4 +259,18 @@ fn escape_edge_label(label: &str) -> String {
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
         .replace('\n', "<br/>")
+}
+
+fn escape_dot_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn escape_plantuml_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
 }

--- a/statum-graph/tests/codebase.rs
+++ b/statum-graph/tests/codebase.rs
@@ -4,12 +4,13 @@ use std::fs;
 
 use statum::{
     LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
-    LinkedTransitionInventory, MachineDescriptor, StaticMachineLinkDescriptor,
+    LinkedTransitionInventory, LinkedValidatorEntryDescriptor, MachineDescriptor,
+    StaticMachineLinkDescriptor,
 };
 use statum_graph::{codebase::render, CodebaseDoc};
 
 mod task {
-    use statum::{machine, state, transition};
+    use statum::{machine, state, transition, validators, Error};
 
     #[state]
     pub enum State {
@@ -37,11 +38,42 @@ mod task {
             self.transition()
         }
     }
+
+    pub struct TaskRow {
+        pub status: &'static str,
+    }
+
+    #[validators(Machine)]
+    impl TaskRow {
+        fn is_idle(&self) -> statum::Result<()> {
+            if self.status == "idle" {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+
+        fn is_running(&self) -> statum::Result<()> {
+            if self.status == "running" {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+
+        fn is_done(&self) -> statum::Result<()> {
+            if self.status == "done" {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+    }
 }
 
 mod workflow {
     use super::*;
-    use statum::{machine, state, transition};
+    use statum::{machine, state, transition, validators, Error};
 
     #[state]
     pub enum State {
@@ -67,6 +99,37 @@ mod workflow {
     impl Machine<InProgress> {
         fn finish(self) -> Machine<Complete> {
             self.transition()
+        }
+    }
+
+    pub struct WorkflowRow {
+        pub status: &'static str,
+    }
+
+    #[validators(Machine)]
+    impl WorkflowRow {
+        fn is_draft(&self) -> statum::Result<()> {
+            if self.status == "draft" {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+
+        fn is_in_progress(&self) -> statum::Result<task::Machine<task::Running>> {
+            if self.status == "in_progress" {
+                Ok(task::Machine::<task::Running>::builder().build())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+
+        fn is_complete(&self) -> statum::Result<()> {
+            if self.status == "complete" {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
         }
     }
 }
@@ -128,6 +191,12 @@ fn linked_codebase_doc_collects_machines_and_links() {
             .map(|state| state.label),
         Some(Some("In Progress"))
     );
+    assert_eq!(workflow.validator_entries.len(), 1);
+    assert_eq!(
+        workflow.validator_entries[0].source_type_display,
+        "WorkflowRow"
+    );
+    assert_eq!(workflow.validator_entries[0].target_states, vec![0, 1, 2]);
 
     let workflow_link = doc
         .links()
@@ -153,6 +222,11 @@ fn linked_codebase_doc_collects_machines_and_links() {
         .expect("named link target state");
     assert!(target_machine.rust_type_path.ends_with("task::Machine"));
     assert_eq!(target_state.rust_name, "Done");
+    assert_eq!(target_machine.validator_entries.len(), 1);
+    assert_eq!(
+        target_machine.validator_entries[0].display_label().as_ref(),
+        "TaskRow::into_machine()"
+    );
 }
 
 #[test]
@@ -233,5 +307,200 @@ fn malformed_inventory_rejects_missing_static_link_source_state() {
             .unwrap_err()
             .to_string(),
         "linked machine `broken::Machine` contains a static payload link from missing source state `Missing`"
+    );
+}
+
+#[test]
+fn malformed_inventory_rejects_missing_validator_machine() {
+    static VALIDATORS: [LinkedValidatorEntryDescriptor; 1] = [LinkedValidatorEntryDescriptor {
+        machine: MachineDescriptor {
+            module_path: "broken",
+            rust_type_path: "broken::Machine",
+        },
+        source_module_path: "broken",
+        source_type_display: "BrokenRow",
+        target_states: &["Draft"],
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked_with_validator_entries(&[], &VALIDATORS)
+            .unwrap_err()
+            .to_string(),
+        "linked validator entry `BrokenRow::into_machine()` from module `broken` points at missing machine `broken::Machine`"
+    );
+}
+
+#[test]
+fn malformed_inventory_rejects_missing_validator_target_state() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &[]
+    }
+
+    static STATES: [LinkedStateDescriptor; 1] = [LinkedStateDescriptor {
+        rust_name: "Draft",
+        label: None,
+        description: None,
+        has_data: false,
+    }];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &[],
+    }];
+    static VALIDATORS: [LinkedValidatorEntryDescriptor; 1] = [LinkedValidatorEntryDescriptor {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        source_module_path: "workflow",
+        source_type_display: "DbRow",
+        target_states: &["Missing"],
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked_with_validator_entries(&LINKED, &VALIDATORS)
+            .unwrap_err()
+            .to_string(),
+        "linked validator entry `DbRow::into_machine()` from module `workflow` points at missing state `workflow::Machine::Missing`"
+    );
+}
+
+#[test]
+fn malformed_inventory_rejects_empty_validator_target_set() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &[]
+    }
+
+    static STATES: [LinkedStateDescriptor; 1] = [LinkedStateDescriptor {
+        rust_name: "Draft",
+        label: None,
+        description: None,
+        has_data: false,
+    }];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &[],
+    }];
+    static VALIDATORS: [LinkedValidatorEntryDescriptor; 1] = [LinkedValidatorEntryDescriptor {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        source_module_path: "workflow",
+        source_type_display: "DbRow",
+        target_states: &[],
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked_with_validator_entries(&LINKED, &VALIDATORS)
+            .unwrap_err()
+            .to_string(),
+        "linked validator entry `DbRow::into_machine()` from module `workflow` for machine `workflow::Machine` contains no target states"
+    );
+}
+
+#[test]
+fn malformed_inventory_rejects_duplicate_validator_target_state() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &[]
+    }
+
+    static STATES: [LinkedStateDescriptor; 1] = [LinkedStateDescriptor {
+        rust_name: "Draft",
+        label: None,
+        description: None,
+        has_data: false,
+    }];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &[],
+    }];
+    static VALIDATORS: [LinkedValidatorEntryDescriptor; 1] = [LinkedValidatorEntryDescriptor {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        source_module_path: "workflow",
+        source_type_display: "DbRow",
+        target_states: &["Draft", "Draft"],
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked_with_validator_entries(&LINKED, &VALIDATORS)
+            .unwrap_err()
+            .to_string(),
+        "linked validator entry `DbRow::into_machine()` from module `workflow` for machine `workflow::Machine` contains duplicate target state `Draft`"
+    );
+}
+
+#[test]
+fn malformed_inventory_rejects_duplicate_validator_entry_identity() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &[]
+    }
+
+    static STATES: [LinkedStateDescriptor; 1] = [LinkedStateDescriptor {
+        rust_name: "Draft",
+        label: None,
+        description: None,
+        has_data: false,
+    }];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "workflow",
+            rust_type_path: "workflow::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &[],
+    }];
+    static VALIDATORS: [LinkedValidatorEntryDescriptor; 2] = [
+        LinkedValidatorEntryDescriptor {
+            machine: MachineDescriptor {
+                module_path: "workflow",
+                rust_type_path: "workflow::Machine",
+            },
+            source_module_path: "workflow",
+            source_type_display: "DbRow",
+            target_states: &["Draft"],
+        },
+        LinkedValidatorEntryDescriptor {
+            machine: MachineDescriptor {
+                module_path: "workflow",
+                rust_type_path: "workflow::Machine",
+            },
+            source_module_path: "workflow",
+            source_type_display: "DbRow",
+            target_states: &["Draft"],
+        },
+    ];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked_with_validator_entries(&LINKED, &VALIDATORS)
+            .unwrap_err()
+            .to_string(),
+        "linked validator entry `DbRow::into_machine()` from module `workflow` appears more than once for machine `workflow::Machine`"
     );
 }

--- a/statum-graph/tests/codebase.rs
+++ b/statum-graph/tests/codebase.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
 
 use statum::{
     LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
@@ -270,6 +272,78 @@ fn linked_codebase_writes_all_formats() {
     let mermaid = fs::read_to_string(mermaid_path).expect("mermaid file");
     assert!(mermaid.contains("Workflow Machine"));
     assert!(mermaid.contains("Task Machine"));
+}
+
+#[test]
+fn linked_codebase_write_all_rejects_path_like_stem() {
+    let doc = CodebaseDoc::linked().expect("linked codebase doc");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let bundle_dir = dir.path().join("nested");
+    let outside = dir.path().join("escape.mmd");
+    let stem = Path::new("..").join("escape");
+
+    let error = render::write_all_to_dir(&doc, &bundle_dir, stem.to_str().expect("utf-8 stem"))
+        .expect_err("path-like stem should be rejected");
+
+    assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    assert!(!bundle_dir.exists());
+    assert!(!outside.exists());
+}
+
+#[test]
+fn malformed_inventory_rejects_missing_transition_source_before_sort() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &TRANSITIONS
+    }
+
+    static STATES: [LinkedStateDescriptor; 2] = [
+        LinkedStateDescriptor {
+            rust_name: "Draft",
+            label: None,
+            description: None,
+            has_data: false,
+        },
+        LinkedStateDescriptor {
+            rust_name: "Review",
+            label: None,
+            description: None,
+            has_data: false,
+        },
+    ];
+    static TRANSITIONS: [LinkedTransitionDescriptor; 2] = [
+        LinkedTransitionDescriptor {
+            method_name: "submit",
+            from: "Draft",
+            to: &["Review"],
+            label: None,
+            description: None,
+        },
+        LinkedTransitionDescriptor {
+            method_name: "ghost",
+            from: "Missing",
+            to: &["Review"],
+            label: None,
+            description: None,
+        },
+    ];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "broken",
+            rust_type_path: "broken::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &[],
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked(&LINKED)
+            .unwrap_err()
+            .to_string(),
+        "linked machine `broken::Machine` contains transition `ghost` whose source state is missing from the state list"
+    );
 }
 
 #[test]

--- a/statum-graph/tests/codebase.rs
+++ b/statum-graph/tests/codebase.rs
@@ -1,0 +1,237 @@
+#![allow(dead_code)]
+
+use std::fs;
+
+use statum::{
+    LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
+    LinkedTransitionInventory, MachineDescriptor, StaticMachineLinkDescriptor,
+};
+use statum_graph::{codebase::render, CodebaseDoc};
+
+mod task {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Idle,
+        #[present(label = "Running")]
+        Running,
+        Done,
+    }
+
+    #[machine]
+    #[present(label = "Task Machine")]
+    pub struct Machine<State> {}
+
+    #[transition]
+    impl Machine<Idle> {
+        #[present(label = "Start Task")]
+        fn start(self) -> Machine<Running> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Machine<Running> {
+        fn finish(self) -> Machine<Done> {
+            self.transition()
+        }
+    }
+}
+
+mod workflow {
+    use super::*;
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Draft,
+        #[present(label = "In Progress")]
+        InProgress(task::Machine<task::Running>),
+        Complete,
+    }
+
+    #[machine]
+    #[present(label = "Workflow Machine")]
+    pub struct Machine<State> {}
+
+    #[transition]
+    impl Machine<Draft> {
+        #[present(label = "Start Workflow")]
+        fn start(self, running_task: task::Machine<task::Running>) -> Machine<InProgress> {
+            self.transition_with(running_task)
+        }
+    }
+
+    #[transition]
+    impl Machine<InProgress> {
+        fn finish(self) -> Machine<Complete> {
+            self.transition()
+        }
+    }
+}
+
+mod named_holder {
+    use super::*;
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        Pending {
+            child: task::Machine<task::Done>,
+            note: &'static str,
+        },
+        Settled,
+    }
+
+    #[machine]
+    pub struct Machine<State> {}
+
+    #[transition]
+    impl Machine<Pending> {
+        fn settle(self) -> Machine<Settled> {
+            self.transition()
+        }
+    }
+}
+
+mod detached {
+    use statum::{machine, state};
+
+    #[state]
+    pub enum State {
+        Alone,
+    }
+
+    #[machine]
+    pub struct Machine<State> {}
+}
+
+#[test]
+fn linked_codebase_doc_collects_machines_and_links() {
+    let doc = CodebaseDoc::linked().expect("linked codebase doc");
+
+    assert_eq!(doc.machines().len(), 4);
+    assert_eq!(doc.links().len(), 2);
+
+    let workflow = doc
+        .machines()
+        .iter()
+        .find(|machine| machine.rust_type_path.ends_with("workflow::Machine"))
+        .expect("workflow machine");
+    assert_eq!(workflow.label, Some("Workflow Machine"));
+    assert_eq!(
+        workflow
+            .states
+            .iter()
+            .find(|state| state.rust_name == "InProgress")
+            .map(|state| state.label),
+        Some(Some("In Progress"))
+    );
+
+    let workflow_link = doc
+        .links()
+        .iter()
+        .find(|link| {
+            doc.machine(link.from_machine)
+                .map(|machine| machine.rust_type_path.ends_with("workflow::Machine"))
+                .unwrap_or(false)
+        })
+        .expect("workflow link");
+    assert_eq!(workflow_link.field_name, None);
+
+    let named_link = doc
+        .links()
+        .iter()
+        .find(|link| link.field_name == Some("child"))
+        .expect("named child link");
+    let target_machine = doc
+        .machine(named_link.to_machine)
+        .expect("named link target machine");
+    let target_state = target_machine
+        .state(named_link.to_state)
+        .expect("named link target state");
+    assert!(target_machine.rust_type_path.ends_with("task::Machine"));
+    assert_eq!(target_state.rust_name, "Done");
+}
+
+#[test]
+fn linked_codebase_renderers_are_stable() {
+    let doc = CodebaseDoc::linked().expect("linked codebase doc");
+
+    insta::assert_snapshot!("linked_codebase_mermaid", render::mermaid(&doc));
+    insta::assert_snapshot!("linked_codebase_dot", render::dot(&doc));
+    insta::assert_snapshot!("linked_codebase_plantuml", render::plantuml(&doc));
+    insta::assert_snapshot!("linked_codebase_json", render::json(&doc));
+}
+
+#[test]
+fn linked_codebase_writes_all_formats() {
+    let doc = CodebaseDoc::linked().expect("linked codebase doc");
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    let paths = render::write_all_to_dir(&doc, dir.path().join("nested"), "codebase")
+        .expect("write linked codebase bundle");
+
+    let file_names = paths
+        .iter()
+        .map(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        file_names,
+        vec![
+            "codebase.mmd",
+            "codebase.dot",
+            "codebase.puml",
+            "codebase.json",
+        ]
+    );
+
+    let mermaid_path = dir.path().join("nested").join("codebase.mmd");
+    assert!(mermaid_path.exists());
+    let mermaid = fs::read_to_string(mermaid_path).expect("mermaid file");
+    assert!(mermaid.contains("Workflow Machine"));
+    assert!(mermaid.contains("Task Machine"));
+}
+
+#[test]
+fn malformed_inventory_rejects_missing_static_link_source_state() {
+    fn transitions() -> &'static [LinkedTransitionDescriptor] {
+        &[]
+    }
+
+    static STATES: [LinkedStateDescriptor; 1] = [LinkedStateDescriptor {
+        rust_name: "Draft",
+        label: None,
+        description: None,
+        has_data: false,
+    }];
+    static LINKS: [StaticMachineLinkDescriptor; 1] = [StaticMachineLinkDescriptor {
+        from_state: "Missing",
+        field_name: None,
+        to_machine_path: &["task", "Machine"],
+        to_state: "Running",
+    }];
+    static LINKED: [LinkedMachineGraph; 1] = [LinkedMachineGraph {
+        machine: MachineDescriptor {
+            module_path: "broken",
+            rust_type_path: "broken::Machine",
+        },
+        label: None,
+        description: None,
+        states: &STATES,
+        transitions: LinkedTransitionInventory::new(transitions),
+        static_links: &LINKS,
+    }];
+
+    assert_eq!(
+        CodebaseDoc::try_from_linked(&LINKED)
+            .unwrap_err()
+            .to_string(),
+        "linked machine `broken::Machine` contains a static payload link from missing source state `Missing`"
+    );
+}

--- a/statum-graph/tests/codebase_ambiguity.rs
+++ b/statum-graph/tests/codebase_ambiguity.rs
@@ -1,0 +1,60 @@
+#![allow(dead_code)]
+
+use statum_graph::{CodebaseDoc, CodebaseDocError};
+
+mod alpha {
+    pub mod shared {
+        use statum::{machine, state};
+
+        #[state]
+        pub enum State {
+            Running,
+        }
+
+        #[machine]
+        pub struct Machine<State> {}
+    }
+}
+
+mod beta {
+    pub mod shared {
+        use statum::{machine, state};
+
+        #[state]
+        pub enum State {
+            Running,
+        }
+
+        #[machine]
+        pub struct Machine<State> {}
+    }
+}
+
+mod holder {
+    use super::alpha::shared;
+    use statum::{machine, state};
+
+    #[state]
+    pub enum State {
+        Uses(shared::Machine<shared::Running>),
+    }
+
+    #[machine]
+    pub struct Machine<State> {}
+}
+
+#[test]
+fn ambiguous_static_links_fail_closed() {
+    let err = CodebaseDoc::linked().expect_err("ambiguous link should fail");
+
+    assert_eq!(
+        err,
+        CodebaseDocError::AmbiguousStaticLink {
+            machine: "codebase_ambiguity::holder::Machine",
+            state: "Uses",
+            field_name: None,
+            target_machine_path: "shared::Machine".to_owned(),
+            target_state: "Running",
+        }
+    );
+}

--- a/statum-graph/tests/codebase_validators.rs
+++ b/statum-graph/tests/codebase_validators.rs
@@ -1,0 +1,124 @@
+#![allow(dead_code)]
+
+use statum_graph::CodebaseDoc;
+
+mod cfg_surface {
+    use statum::{machine, state, validators, Error};
+
+    #[state]
+    pub enum State {
+        Draft,
+        Done,
+    }
+
+    #[machine]
+    pub struct Machine<State> {}
+
+    pub struct VisibleRow {
+        pub done: bool,
+    }
+
+    #[validators(Machine)]
+    impl VisibleRow {
+        fn is_draft(&self) -> statum::Result<()> {
+            if !self.done {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+
+        fn is_done(&self) -> statum::Result<()> {
+            if self.done {
+                Ok(())
+            } else {
+                Err(Error::InvalidState)
+            }
+        }
+    }
+
+    pub struct HiddenRow;
+
+    #[cfg(any())]
+    #[validators(Machine)]
+    impl HiddenRow {
+        fn is_draft(&self) -> statum::Result<()> {
+            Ok(())
+        }
+
+        fn is_done(&self) -> statum::Result<()> {
+            Ok(())
+        }
+    }
+}
+
+mod macro_surface {
+    use statum::{machine, state, validators, Error};
+
+    #[state]
+    pub enum State {
+        Draft,
+        Done,
+    }
+
+    #[machine]
+    pub struct Machine<State> {}
+
+    pub struct MacroRow {
+        pub done: bool,
+    }
+
+    macro_rules! define_validators {
+        () => {
+            #[validators(Machine)]
+            impl MacroRow {
+                fn is_draft(&self) -> statum::Result<()> {
+                    if !self.done {
+                        Ok(())
+                    } else {
+                        Err(Error::InvalidState)
+                    }
+                }
+
+                fn is_done(&self) -> statum::Result<()> {
+                    if self.done {
+                        Ok(())
+                    } else {
+                        Err(Error::InvalidState)
+                    }
+                }
+            }
+        };
+    }
+
+    define_validators!();
+}
+
+#[test]
+fn linked_codebase_uses_compiled_validator_impl_surfaces() {
+    let doc = CodebaseDoc::linked().expect("linked codebase doc");
+
+    let cfg_machine = doc
+        .machines()
+        .iter()
+        .find(|machine| machine.rust_type_path.ends_with("cfg_surface::Machine"))
+        .expect("cfg machine");
+    assert_eq!(cfg_machine.validator_entries.len(), 1);
+    assert_eq!(
+        cfg_machine.validator_entries[0].source_type_display,
+        "VisibleRow"
+    );
+    assert_eq!(cfg_machine.validator_entries[0].target_states, vec![0, 1]);
+
+    let macro_machine = doc
+        .machines()
+        .iter()
+        .find(|machine| machine.rust_type_path.ends_with("macro_surface::Machine"))
+        .expect("macro machine");
+    assert_eq!(macro_machine.validator_entries.len(), 1);
+    assert_eq!(
+        macro_machine.validator_entries[0].source_type_display,
+        "MacroRow"
+    );
+    assert_eq!(macro_machine.validator_entries[0].target_states, vec![0, 1]);
+}

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
@@ -455,6 +457,22 @@ fn write_all_to_dir_writes_every_format_with_stable_extensions() {
         fs::read_to_string(&paths[3]).expect("json file should exist"),
         render::json(&doc)
     );
+}
+
+#[test]
+fn write_all_to_dir_rejects_path_like_stem() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let bundle_dir = tempdir.path().join("bundle");
+    let outside = tempdir.path().join("escape.mmd");
+    let stem = Path::new("..").join("escape");
+
+    let error = render::write_all_to_dir(&doc, &bundle_dir, stem.to_str().expect("utf-8 stem"))
+        .expect_err("path-like stem should be rejected");
+
+    assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    assert!(!bundle_dir.exists());
+    assert!(!outside.exists());
 }
 
 #[test]

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -794,6 +794,20 @@ static DUPLICATE_STATE_PRESENTATIONS: [StatePresentation<InvalidStateId>; 2] = [
         metadata: (),
     },
 ];
+static DUPLICATE_EMPTY_STATE_PRESENTATIONS: [StatePresentation<InvalidStateId>; 2] = [
+    StatePresentation {
+        id: InvalidStateId::Draft,
+        label: None,
+        description: None,
+        metadata: (),
+    },
+    StatePresentation {
+        id: InvalidStateId::Draft,
+        label: None,
+        description: None,
+        metadata: (),
+    },
+];
 
 static EMPTY_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 0] = [];
 static UNKNOWN_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 1] =
@@ -817,6 +831,20 @@ static DUPLICATE_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransi
         metadata: (),
     },
 ];
+static DUPLICATE_EMPTY_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 2] = [
+    TransitionPresentation {
+        id: InvalidTransitionId::Submit,
+        label: None,
+        description: None,
+        metadata: (),
+    },
+    TransitionPresentation {
+        id: InvalidTransitionId::Submit,
+        label: None,
+        description: None,
+        metadata: (),
+    },
+];
 
 static UNKNOWN_STATE_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
     MachinePresentation {
@@ -836,6 +864,15 @@ static DUPLICATE_STATE_PRESENTATION: MachinePresentation<InvalidStateId, Invalid
         transitions: TransitionPresentationInventory::new(|| &EMPTY_TRANSITION_PRESENTATIONS),
     };
 
+static DUPLICATE_EMPTY_STATE_PRESENTATION: MachinePresentation<
+    InvalidStateId,
+    InvalidTransitionId,
+> = MachinePresentation {
+    machine: None,
+    states: &DUPLICATE_EMPTY_STATE_PRESENTATIONS,
+    transitions: TransitionPresentationInventory::new(|| &EMPTY_TRANSITION_PRESENTATIONS),
+};
+
 static UNKNOWN_TRANSITION_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
     MachinePresentation {
         machine: None,
@@ -849,6 +886,15 @@ static DUPLICATE_TRANSITION_PRESENTATION: MachinePresentation<InvalidStateId, In
         states: &EMPTY_STATE_PRESENTATIONS,
         transitions: TransitionPresentationInventory::new(|| &DUPLICATE_TRANSITION_PRESENTATIONS),
     };
+
+static DUPLICATE_EMPTY_TRANSITION_PRESENTATION: MachinePresentation<
+    InvalidStateId,
+    InvalidTransitionId,
+> = MachinePresentation {
+    machine: None,
+    states: &EMPTY_STATE_PRESENTATIONS,
+    transitions: TransitionPresentationInventory::new(|| &DUPLICATE_EMPTY_TRANSITION_PRESENTATIONS),
+};
 
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
@@ -998,6 +1044,19 @@ fn rejects_presentation_with_duplicate_state_id() {
 }
 
 #[test]
+fn rejects_presentation_with_duplicate_state_id_when_first_entry_is_empty() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&DUPLICATE_EMPTY_STATE_PRESENTATION),
+        Err(ExportDocError::DuplicateStatePresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 1,
+        })
+    );
+}
+
+#[test]
 fn rejects_presentation_with_unknown_transition_id() {
     let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
 
@@ -1016,6 +1075,19 @@ fn rejects_presentation_with_duplicate_transition_id() {
 
     assert_eq!(
         doc.export_with_presentation(&DUPLICATE_TRANSITION_PRESENTATION),
+        Err(ExportDocError::DuplicateTransitionPresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 1,
+        })
+    );
+}
+
+#[test]
+fn rejects_presentation_with_duplicate_transition_id_when_first_entry_is_empty() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&DUPLICATE_EMPTY_TRANSITION_PRESENTATION),
         Err(ExportDocError::DuplicateTransitionPresentation {
             machine: "tests::valid_presentation::Flow",
             entry: 1,

--- a/statum-graph/tests/export.rs
+++ b/statum-graph/tests/export.rs
@@ -1,12 +1,15 @@
 #![allow(dead_code)]
 
+use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use statum::{
-    MachineDescriptor, MachineGraph, StateDescriptor, TransitionDescriptor, TransitionInventory,
+    MachineDescriptor, MachineGraph, MachinePresentation, MachinePresentationDescriptor,
+    StateDescriptor, StatePresentation, TransitionDescriptor, TransitionInventory,
+    TransitionPresentation, TransitionPresentationInventory,
 };
-use statum_graph::{render, MachineDoc, MachineDocError};
+use statum_graph::{render, ExportDocError, MachineDoc, MachineDocError};
 
 mod linear {
     use statum::{machine, state, transition};
@@ -190,6 +193,42 @@ mod macro_generated {
     generated_transitions!();
 }
 
+mod presented {
+    use statum::{machine, state, transition};
+
+    #[state]
+    pub enum State {
+        #[present(label = "Queued", description = "Waiting for work.")]
+        Queued,
+        #[present(label = "Running")]
+        Running,
+        Done,
+    }
+
+    #[machine]
+    #[present(
+        label = "Presented Flow",
+        description = "Presentation metadata for renderer output."
+    )]
+    pub struct Flow<State> {}
+
+    #[transition]
+    impl Flow<Queued> {
+        #[present(label = "Start", description = "Begin running queued work.")]
+        fn start(self) -> Flow<Running> {
+            self.transition()
+        }
+    }
+
+    #[transition]
+    impl Flow<Running> {
+        #[present(label = "Finish")]
+        fn finish(self) -> Flow<Done> {
+            self.transition()
+        }
+    }
+}
+
 #[test]
 fn exports_linear_machine_topology_from_graph() {
     let doc = MachineDoc::from_machine::<linear::Flow<linear::Draft>>();
@@ -283,6 +322,139 @@ fn mermaid_renders_one_edge_per_legal_target() {
     assert_eq!(mermaid.matches("-->|maybe_decide|").count(), 2);
     assert!(mermaid.contains("s1 -->|maybe_decide| s2"));
     assert!(mermaid.contains("s1 -->|maybe_decide| s3"));
+}
+
+#[test]
+fn export_doc_joins_generated_presentation_labels_and_descriptions() {
+    let doc = MachineDoc::from_machine::<presented::Flow<presented::Queued>>();
+    let export = doc
+        .export_with_presentation(&presented::flow::PRESENTATION)
+        .expect("generated presentation should join cleanly");
+
+    assert_eq!(
+        export.machine(),
+        statum_graph::ExportMachine {
+            module_path: "export::presented",
+            rust_type_path: "export::presented::Flow",
+            label: Some("Presented Flow"),
+            description: Some("Presentation metadata for renderer output."),
+        }
+    );
+    assert_eq!(
+        export
+            .states()
+            .iter()
+            .map(|state| (state.rust_name, state.label, state.description))
+            .collect::<Vec<_>>(),
+        vec![
+            ("Queued", Some("Queued"), Some("Waiting for work.")),
+            ("Running", Some("Running"), None),
+            ("Done", None, None),
+        ]
+    );
+    assert_eq!(
+        export
+            .transitions()
+            .iter()
+            .map(|transition| {
+                (
+                    transition.method_name,
+                    transition.label,
+                    transition.description,
+                    transition.from,
+                    transition.to.clone(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "start",
+                Some("Start"),
+                Some("Begin running queued work."),
+                0,
+                vec![1]
+            ),
+            ("finish", Some("Finish"), None, 1, vec![2]),
+        ]
+    );
+}
+
+#[test]
+fn dot_snapshot_is_stable_for_reconverging_graphs() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    insta::assert_snapshot!("branching_flow_dot", render::dot(&doc));
+}
+
+#[test]
+fn plantuml_snapshot_is_stable_for_reconverging_graphs() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    insta::assert_snapshot!("branching_flow_plantuml", render::plantuml(&doc));
+}
+
+#[test]
+fn json_snapshot_is_stable_for_presentation_overlay() {
+    let doc = MachineDoc::from_machine::<presented::Flow<presented::Queued>>();
+    let export = doc
+        .export_with_presentation(&presented::flow::PRESENTATION)
+        .expect("generated presentation should join cleanly");
+
+    insta::assert_snapshot!("presented_flow_json", render::json(&export));
+}
+
+#[test]
+fn format_write_to_creates_parent_dirs_and_writes_requested_format() {
+    let doc = MachineDoc::from_machine::<presented::Flow<presented::Queued>>();
+    let export = doc
+        .export_with_presentation(&presented::flow::PRESENTATION)
+        .expect("generated presentation should join cleanly");
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("nested/graph.json");
+
+    let written = render::Format::Json
+        .write_to(&export, &path)
+        .expect("json output should write");
+
+    assert_eq!(written, path);
+    assert_eq!(
+        fs::read_to_string(&path).expect("json file should exist"),
+        render::json(&export)
+    );
+}
+
+#[test]
+fn write_all_to_dir_writes_every_format_with_stable_extensions() {
+    let doc = MachineDoc::from_machine::<branching::Flow<branching::Draft>>();
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let bundle_dir = tempdir.path().join("bundle");
+
+    let paths =
+        render::write_all_to_dir(&doc, &bundle_dir, "flow").expect("bundle output should write");
+
+    assert_eq!(
+        paths,
+        vec![
+            bundle_dir.join("flow.mmd"),
+            bundle_dir.join("flow.dot"),
+            bundle_dir.join("flow.puml"),
+            bundle_dir.join("flow.json"),
+        ]
+    );
+    assert_eq!(
+        fs::read_to_string(&paths[0]).expect("mermaid file should exist"),
+        render::mermaid(&doc)
+    );
+    assert_eq!(
+        fs::read_to_string(&paths[1]).expect("dot file should exist"),
+        render::dot(&doc)
+    );
+    assert_eq!(
+        fs::read_to_string(&paths[2]).expect("plantuml file should exist"),
+        render::plantuml(&doc)
+    );
+    assert_eq!(
+        fs::read_to_string(&paths[3]).expect("json file should exist"),
+        render::json(&doc)
+    );
 }
 
 #[test]
@@ -543,6 +715,10 @@ fn empty_target_transitions() -> &'static [TransitionDescriptor<InvalidStateId, 
     &EMPTY_TARGET_TRANSITIONS
 }
 
+fn valid_transitions() -> &'static [TransitionDescriptor<InvalidStateId, InvalidTransitionId>] {
+    &FLAKY_VALID_TRANSITIONS
+}
+
 static FLAKY_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
     machine: MachineDescriptor {
         module_path: "tests::flaky_inventory",
@@ -569,6 +745,92 @@ static EMPTY_TARGET_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = M
     states: &VALID_STATE_DESCRIPTORS,
     transitions: TransitionInventory::new(empty_target_transitions),
 };
+
+static VALID_GRAPH: MachineGraph<InvalidStateId, InvalidTransitionId> = MachineGraph {
+    machine: MachineDescriptor {
+        module_path: "tests::valid_presentation",
+        rust_type_path: "tests::valid_presentation::Flow",
+    },
+    states: &VALID_STATE_DESCRIPTORS,
+    transitions: TransitionInventory::new(valid_transitions),
+};
+
+static EMPTY_STATE_PRESENTATIONS: [StatePresentation<InvalidStateId>; 0] = [];
+static UNKNOWN_STATE_PRESENTATIONS: [StatePresentation<InvalidStateId>; 1] = [StatePresentation {
+    id: InvalidStateId::Missing,
+    label: Some("Missing"),
+    description: None,
+    metadata: (),
+}];
+static DUPLICATE_STATE_PRESENTATIONS: [StatePresentation<InvalidStateId>; 2] = [
+    StatePresentation {
+        id: InvalidStateId::Draft,
+        label: Some("Draft"),
+        description: None,
+        metadata: (),
+    },
+    StatePresentation {
+        id: InvalidStateId::Draft,
+        label: Some("Draft Again"),
+        description: None,
+        metadata: (),
+    },
+];
+
+static EMPTY_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 0] = [];
+static UNKNOWN_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 1] =
+    [TransitionPresentation {
+        id: InvalidTransitionId::Archive,
+        label: Some("Archive"),
+        description: None,
+        metadata: (),
+    }];
+static DUPLICATE_TRANSITION_PRESENTATIONS: [TransitionPresentation<InvalidTransitionId>; 2] = [
+    TransitionPresentation {
+        id: InvalidTransitionId::Submit,
+        label: Some("Submit"),
+        description: None,
+        metadata: (),
+    },
+    TransitionPresentation {
+        id: InvalidTransitionId::Submit,
+        label: Some("Submit Again"),
+        description: None,
+        metadata: (),
+    },
+];
+
+static UNKNOWN_STATE_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
+    MachinePresentation {
+        machine: Some(MachinePresentationDescriptor {
+            label: Some("Invalid"),
+            description: None,
+            metadata: (),
+        }),
+        states: &UNKNOWN_STATE_PRESENTATIONS,
+        transitions: TransitionPresentationInventory::new(|| &EMPTY_TRANSITION_PRESENTATIONS),
+    };
+
+static DUPLICATE_STATE_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
+    MachinePresentation {
+        machine: None,
+        states: &DUPLICATE_STATE_PRESENTATIONS,
+        transitions: TransitionPresentationInventory::new(|| &EMPTY_TRANSITION_PRESENTATIONS),
+    };
+
+static UNKNOWN_TRANSITION_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
+    MachinePresentation {
+        machine: None,
+        states: &EMPTY_STATE_PRESENTATIONS,
+        transitions: TransitionPresentationInventory::new(|| &UNKNOWN_TRANSITION_PRESENTATIONS),
+    };
+
+static DUPLICATE_TRANSITION_PRESENTATION: MachinePresentation<InvalidStateId, InvalidTransitionId> =
+    MachinePresentation {
+        machine: None,
+        states: &EMPTY_STATE_PRESENTATIONS,
+        transitions: TransitionPresentationInventory::new(|| &DUPLICATE_TRANSITION_PRESENTATIONS),
+    };
 
 #[test]
 fn rejects_external_graph_with_missing_transition_source() {
@@ -688,5 +950,57 @@ fn snapshots_external_transition_inventory_once_per_export() {
             .map(|edge| edge.descriptor.method_name)
             .collect::<Vec<_>>(),
         vec!["submit"]
+    );
+}
+
+#[test]
+fn rejects_presentation_with_unknown_state_id() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&UNKNOWN_STATE_PRESENTATION),
+        Err(ExportDocError::UnknownStatePresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 0,
+        })
+    );
+}
+
+#[test]
+fn rejects_presentation_with_duplicate_state_id() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&DUPLICATE_STATE_PRESENTATION),
+        Err(ExportDocError::DuplicateStatePresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 1,
+        })
+    );
+}
+
+#[test]
+fn rejects_presentation_with_unknown_transition_id() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&UNKNOWN_TRANSITION_PRESENTATION),
+        Err(ExportDocError::UnknownTransitionPresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 0,
+        })
+    );
+}
+
+#[test]
+fn rejects_presentation_with_duplicate_transition_id() {
+    let doc = MachineDoc::try_from_graph(&VALID_GRAPH).expect("valid external graph should export");
+
+    assert_eq!(
+        doc.export_with_presentation(&DUPLICATE_TRANSITION_PRESENTATION),
+        Err(ExportDocError::DuplicateTransitionPresentation {
+            machine: "tests::valid_presentation::Flow",
+            entry: 1,
+        })
     );
 }

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_dot.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_dot.snap
@@ -1,0 +1,37 @@
+---
+source: statum-graph/tests/codebase.rs
+expression: "render::dot(&doc)"
+---
+digraph "statum_codebase" {
+    rankdir=TB;
+    subgraph "cluster_m0" {
+        label="codebase::detached::Machine";
+        m0_s0 [label="Alone"]
+    }
+    subgraph "cluster_m1" {
+        label="codebase::named_holder::Machine";
+        m1_s0 [label="Pending (data)"]
+        m1_s1 [label="Settled"]
+    }
+    subgraph "cluster_m2" {
+        label="Task Machine";
+        m2_s0 [label="Idle"]
+        m2_s1 [label="Running"]
+        m2_s2 [label="Done"]
+    }
+    subgraph "cluster_m3" {
+        label="Workflow Machine";
+        m3_s0 [label="Draft"]
+        m3_s1 [label="In Progress"]
+        m3_s2 [label="Complete"]
+    }
+
+    m1_s0 -> m1_s1 [label="settle"]
+    m2_s0 -> m2_s1 [label="Start Task"]
+    m2_s1 -> m2_s2 [label="finish"]
+    m3_s0 -> m3_s1 [label="Start Workflow"]
+    m3_s1 -> m3_s2 [label="finish"]
+
+    m1_s0 -> m2_s2 [style=dashed, label="child"]
+    m3_s1 -> m2_s1 [style=dashed, label="state_data"]
+}

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_dot.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_dot.snap
@@ -26,6 +26,9 @@ digraph "statum_codebase" {
         m3_s2 [label="Complete"]
     }
 
+    m2_v0 [label="TaskRow::into_machine()", shape=ellipse, style="rounded,dashed", color="#4b5563"]
+    m3_v0 [label="WorkflowRow::into_machine()", shape=ellipse, style="rounded,dashed", color="#4b5563"]
+
     m1_s0 -> m1_s1 [label="settle"]
     m2_s0 -> m2_s1 [label="Start Task"]
     m2_s1 -> m2_s2 [label="finish"]
@@ -34,4 +37,11 @@ digraph "statum_codebase" {
 
     m1_s0 -> m2_s2 [style=dashed, label="child"]
     m3_s1 -> m2_s1 [style=dashed, label="state_data"]
+
+    m2_v0 -> m2_s0 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
+    m2_v0 -> m2_s1 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
+    m2_v0 -> m2_s2 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
+    m3_v0 -> m3_s0 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
+    m3_v0 -> m3_s1 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
+    m3_v0 -> m3_s2 [style=dashed, color="#4b5563", penwidth=2, constraint=false]
 }

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_json.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_json.snap
@@ -1,0 +1,191 @@
+---
+source: statum-graph/tests/codebase.rs
+expression: "render::json(&doc)"
+---
+{
+  "machines": [
+    {
+      "index": 0,
+      "module_path": "codebase::detached",
+      "rust_type_path": "codebase::detached::Machine",
+      "label": null,
+      "description": null,
+      "states": [
+        {
+          "index": 0,
+          "rust_name": "Alone",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": true
+        }
+      ],
+      "transitions": []
+    },
+    {
+      "index": 1,
+      "module_path": "codebase::named_holder",
+      "rust_type_path": "codebase::named_holder::Machine",
+      "label": null,
+      "description": null,
+      "states": [
+        {
+          "index": 0,
+          "rust_name": "Pending",
+          "label": null,
+          "description": null,
+          "has_data": true,
+          "is_root": true
+        },
+        {
+          "index": 1,
+          "rust_name": "Settled",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": false
+        }
+      ],
+      "transitions": [
+        {
+          "index": 0,
+          "method_name": "settle",
+          "label": null,
+          "description": null,
+          "from": 0,
+          "to": [
+            1
+          ]
+        }
+      ]
+    },
+    {
+      "index": 2,
+      "module_path": "codebase::task",
+      "rust_type_path": "codebase::task::Machine",
+      "label": "Task Machine",
+      "description": null,
+      "states": [
+        {
+          "index": 0,
+          "rust_name": "Idle",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": true
+        },
+        {
+          "index": 1,
+          "rust_name": "Running",
+          "label": "Running",
+          "description": null,
+          "has_data": false,
+          "is_root": false
+        },
+        {
+          "index": 2,
+          "rust_name": "Done",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": false
+        }
+      ],
+      "transitions": [
+        {
+          "index": 0,
+          "method_name": "start",
+          "label": "Start Task",
+          "description": null,
+          "from": 0,
+          "to": [
+            1
+          ]
+        },
+        {
+          "index": 1,
+          "method_name": "finish",
+          "label": null,
+          "description": null,
+          "from": 1,
+          "to": [
+            2
+          ]
+        }
+      ]
+    },
+    {
+      "index": 3,
+      "module_path": "codebase::workflow",
+      "rust_type_path": "codebase::workflow::Machine",
+      "label": "Workflow Machine",
+      "description": null,
+      "states": [
+        {
+          "index": 0,
+          "rust_name": "Draft",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": true
+        },
+        {
+          "index": 1,
+          "rust_name": "InProgress",
+          "label": "In Progress",
+          "description": null,
+          "has_data": true,
+          "is_root": false
+        },
+        {
+          "index": 2,
+          "rust_name": "Complete",
+          "label": null,
+          "description": null,
+          "has_data": false,
+          "is_root": false
+        }
+      ],
+      "transitions": [
+        {
+          "index": 0,
+          "method_name": "start",
+          "label": "Start Workflow",
+          "description": null,
+          "from": 0,
+          "to": [
+            1
+          ]
+        },
+        {
+          "index": 1,
+          "method_name": "finish",
+          "label": null,
+          "description": null,
+          "from": 1,
+          "to": [
+            2
+          ]
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "index": 0,
+      "from_machine": 1,
+      "from_state": 0,
+      "field_name": "child",
+      "to_machine": 2,
+      "to_state": 2
+    },
+    {
+      "index": 1,
+      "from_machine": 3,
+      "from_state": 1,
+      "field_name": null,
+      "to_machine": 2,
+      "to_state": 1
+    }
+  ]
+}

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_json.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_json.snap
@@ -17,10 +17,11 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": true
+          "is_graph_root": true
         }
       ],
-      "transitions": []
+      "transitions": [],
+      "validator_entries": []
     },
     {
       "index": 1,
@@ -35,7 +36,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": true,
-          "is_root": true
+          "is_graph_root": true
         },
         {
           "index": 1,
@@ -43,7 +44,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": false
+          "is_graph_root": false
         }
       ],
       "transitions": [
@@ -57,7 +58,8 @@ expression: "render::json(&doc)"
             1
           ]
         }
-      ]
+      ],
+      "validator_entries": []
     },
     {
       "index": 2,
@@ -72,7 +74,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": true
+          "is_graph_root": true
         },
         {
           "index": 1,
@@ -80,7 +82,7 @@ expression: "render::json(&doc)"
           "label": "Running",
           "description": null,
           "has_data": false,
-          "is_root": false
+          "is_graph_root": false
         },
         {
           "index": 2,
@@ -88,7 +90,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": false
+          "is_graph_root": false
         }
       ],
       "transitions": [
@@ -112,6 +114,18 @@ expression: "render::json(&doc)"
             2
           ]
         }
+      ],
+      "validator_entries": [
+        {
+          "index": 0,
+          "source_module_path": "codebase::task",
+          "source_type_display": "TaskRow",
+          "target_states": [
+            0,
+            1,
+            2
+          ]
+        }
       ]
     },
     {
@@ -127,7 +141,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": true
+          "is_graph_root": true
         },
         {
           "index": 1,
@@ -135,7 +149,7 @@ expression: "render::json(&doc)"
           "label": "In Progress",
           "description": null,
           "has_data": true,
-          "is_root": false
+          "is_graph_root": false
         },
         {
           "index": 2,
@@ -143,7 +157,7 @@ expression: "render::json(&doc)"
           "label": null,
           "description": null,
           "has_data": false,
-          "is_root": false
+          "is_graph_root": false
         }
       ],
       "transitions": [
@@ -164,6 +178,18 @@ expression: "render::json(&doc)"
           "description": null,
           "from": 1,
           "to": [
+            2
+          ]
+        }
+      ],
+      "validator_entries": [
+        {
+          "index": 0,
+          "source_module_path": "codebase::workflow",
+          "source_type_display": "WorkflowRow",
+          "target_states": [
+            0,
+            1,
             2
           ]
         }

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_mermaid.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_mermaid.snap
@@ -22,6 +22,9 @@ graph TD
         m3_s2["Complete"]
     end
 
+    m2_v0("TaskRow::into_machine()")
+    m3_v0("WorkflowRow::into_machine()")
+
     m1_s0 -->|settle| m1_s1
     m2_s0 -->|Start Task| m2_s1
     m2_s1 -->|finish| m2_s2
@@ -30,3 +33,10 @@ graph TD
 
     m1_s0 -.->|child| m2_s2
     m3_s1 -.->|state_data| m2_s1
+
+    m2_v0 -.-> m2_s0
+    m2_v0 -.-> m2_s1
+    m2_v0 -.-> m2_s2
+    m3_v0 -.-> m3_s0
+    m3_v0 -.-> m3_s1
+    m3_v0 -.-> m3_s2

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_mermaid.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_mermaid.snap
@@ -1,0 +1,32 @@
+---
+source: statum-graph/tests/codebase.rs
+expression: "render::mermaid(&doc)"
+---
+%% linked machines: 4
+graph TD
+    subgraph m0["codebase::detached::Machine"]
+        m0_s0["Alone"]
+    end
+    subgraph m1["codebase::named_holder::Machine"]
+        m1_s0["Pending (data)"]
+        m1_s1["Settled"]
+    end
+    subgraph m2["Task Machine"]
+        m2_s0["Idle"]
+        m2_s1["Running"]
+        m2_s2["Done"]
+    end
+    subgraph m3["Workflow Machine"]
+        m3_s0["Draft"]
+        m3_s1["In Progress"]
+        m3_s2["Complete"]
+    end
+
+    m1_s0 -->|settle| m1_s1
+    m2_s0 -->|Start Task| m2_s1
+    m2_s1 -->|finish| m2_s2
+    m3_s0 -->|Start Workflow| m3_s1
+    m3_s1 -->|finish| m3_s2
+
+    m1_s0 -.->|child| m2_s2
+    m3_s1 -.->|state_data| m2_s1

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_plantuml.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_plantuml.snap
@@ -22,6 +22,9 @@ state "Workflow Machine" as m3 {
     state "Complete" as m3_s2
 }
 
+state "TaskRow::into_machine()" as m2_v0 <<validator-entry>>
+state "WorkflowRow::into_machine()" as m3_v0 <<validator-entry>>
+
 m1_s0 --> m1_s1 : settle
 m2_s0 --> m2_s1 : Start Task
 m2_s1 --> m2_s2 : finish
@@ -30,4 +33,11 @@ m3_s1 --> m3_s2 : finish
 
 m1_s0 ..> m2_s2 : child
 m3_s1 ..> m2_s1 : state_data
+
+m2_v0 ..> m2_s0 : validator entry
+m2_v0 ..> m2_s1 : validator entry
+m2_v0 ..> m2_s2 : validator entry
+m3_v0 ..> m3_s0 : validator entry
+m3_v0 ..> m3_s1 : validator entry
+m3_v0 ..> m3_s2 : validator entry
 @enduml

--- a/statum-graph/tests/snapshots/codebase__linked_codebase_plantuml.snap
+++ b/statum-graph/tests/snapshots/codebase__linked_codebase_plantuml.snap
@@ -1,0 +1,33 @@
+---
+source: statum-graph/tests/codebase.rs
+expression: "render::plantuml(&doc)"
+---
+@startuml
+' linked machines: 4
+state "codebase::detached::Machine" as m0 {
+    state "Alone" as m0_s0
+}
+state "codebase::named_holder::Machine" as m1 {
+    state "Pending (data)" as m1_s0
+    state "Settled" as m1_s1
+}
+state "Task Machine" as m2 {
+    state "Idle" as m2_s0
+    state "Running" as m2_s1
+    state "Done" as m2_s2
+}
+state "Workflow Machine" as m3 {
+    state "Draft" as m3_s0
+    state "In Progress" as m3_s1
+    state "Complete" as m3_s2
+}
+
+m1_s0 --> m1_s1 : settle
+m2_s0 --> m2_s1 : Start Task
+m2_s1 --> m2_s2 : finish
+m3_s0 --> m3_s1 : Start Workflow
+m3_s1 --> m3_s2 : finish
+
+m1_s0 ..> m2_s2 : child
+m3_s1 ..> m2_s1 : state_data
+@enduml

--- a/statum-graph/tests/snapshots/export__branching_flow_dot.snap
+++ b/statum-graph/tests/snapshots/export__branching_flow_dot.snap
@@ -1,0 +1,21 @@
+---
+source: statum-graph/tests/export.rs
+assertion_line: 384
+expression: "render::dot(&doc)"
+---
+digraph "export::branching::Flow" {
+    rankdir=TB;
+    s0 [label="Draft"]
+    s1 [label="Review"]
+    s2 [label="Accepted"]
+    s3 [label="Rejected"]
+    s4 [label="Archived"]
+
+    s0 -> s1 [label="submit"]
+    s1 -> s2 [label="accept"]
+    s1 -> s2 [label="maybe_decide"]
+    s1 -> s3 [label="maybe_decide"]
+    s1 -> s3 [label="reject"]
+    s2 -> s4 [label="archive"]
+    s3 -> s4 [label="archive"]
+}

--- a/statum-graph/tests/snapshots/export__branching_flow_plantuml.snap
+++ b/statum-graph/tests/snapshots/export__branching_flow_plantuml.snap
@@ -1,0 +1,20 @@
+---
+source: statum-graph/tests/export.rs
+assertion_line: 390
+expression: "render::plantuml(&doc)"
+---
+@startuml
+state "Draft" as s0
+state "Review" as s1
+state "Accepted" as s2
+state "Rejected" as s3
+state "Archived" as s4
+
+s0 --> s1 : submit
+s1 --> s2 : accept
+s1 --> s2 : maybe_decide
+s1 --> s3 : maybe_decide
+s1 --> s3 : reject
+s2 --> s4 : archive
+s3 --> s4 : archive
+@enduml

--- a/statum-graph/tests/snapshots/export__presented_flow_json.snap
+++ b/statum-graph/tests/snapshots/export__presented_flow_json.snap
@@ -1,0 +1,61 @@
+---
+source: statum-graph/tests/export.rs
+assertion_line: 400
+expression: "render::json(&export)"
+---
+{
+  "machine": {
+    "module_path": "export::presented",
+    "rust_type_path": "export::presented::Flow",
+    "label": "Presented Flow",
+    "description": "Presentation metadata for renderer output."
+  },
+  "states": [
+    {
+      "index": 0,
+      "rust_name": "Queued",
+      "label": "Queued",
+      "description": "Waiting for work.",
+      "has_data": false,
+      "is_root": true
+    },
+    {
+      "index": 1,
+      "rust_name": "Running",
+      "label": "Running",
+      "description": null,
+      "has_data": false,
+      "is_root": false
+    },
+    {
+      "index": 2,
+      "rust_name": "Done",
+      "label": null,
+      "description": null,
+      "has_data": false,
+      "is_root": false
+    }
+  ],
+  "transitions": [
+    {
+      "index": 0,
+      "method_name": "start",
+      "label": "Start",
+      "description": "Begin running queued work.",
+      "from": 0,
+      "to": [
+        1
+      ]
+    },
+    {
+      "index": 1,
+      "method_name": "finish",
+      "label": "Finish",
+      "description": null,
+      "from": 1,
+      "to": [
+        2
+      ]
+    }
+  ]
+}

--- a/statum-macros/src/lib.rs
+++ b/statum-macros/src/lib.rs
@@ -155,11 +155,12 @@ pub fn transition(
 /// `.build_reports()`.
 #[proc_macro_attribute]
 pub fn validators(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let line_number = Span::call_site().start().line;
     let module_path = match resolved_current_module_path(Span::call_site(), "#[validators]") {
         Ok(path) => path,
         Err(err) => return err,
     };
-    parse_validators(attr, item, &module_path)
+    parse_validators(attr, item, &module_path, line_number)
 }
 
 #[doc(hidden)]

--- a/statum-macros/src/machine/emission.rs
+++ b/statum-macros/src/machine/emission.rs
@@ -1,6 +1,9 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{GenericParam, Generics, Ident, ItemStruct, LitStr};
+use syn::{
+    GenericArgument, GenericParam, Generics, Ident, ItemStruct, LitStr, PathArguments, Type,
+    TypePath,
+};
 
 use crate::state::{
     state_family_target_resolver_macro_ident, state_family_visitor_macro_ident,
@@ -11,7 +14,8 @@ use super::metadata::{ParsedMachineInfo, field_type_alias_name};
 use super::{
     MachineInfo, builder_generics, extra_generics, extra_type_arguments_tokens,
     generic_argument_tokens,
-    machine_type_with_state, transition_presentation_slice_ident, transition_slice_ident,
+    linked_transition_slice_ident, machine_type_with_state,
+    transition_presentation_slice_ident, transition_slice_ident,
 };
 
 pub fn generate_machine_impls(
@@ -2108,6 +2112,8 @@ fn generate_machine_state_surface(
 
 fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<TokenStream, TokenStream> {
     let presentation_types = resolve_presentation_types(machine_info)?;
+    let linked_state_entries = linked_state_entries(machine_info)?;
+    let static_machine_link_entries = static_machine_link_entries(machine_info)?;
     let state_presentation_entry_macro_ident =
         machine_state_presentation_entry_macro_ident(machine_info);
     let transition_slice_ident = transition_slice_ident(
@@ -2116,6 +2122,11 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
         machine_info.line_number,
     );
     let transition_presentation_slice_ident = transition_presentation_slice_ident(
+        &machine_info.name,
+        machine_info.file_path.as_deref(),
+        machine_info.line_number,
+    );
+    let linked_transition_slice_ident = linked_transition_slice_ident(
         &machine_info.name,
         machine_info.file_path.as_deref(),
         machine_info.line_number,
@@ -2130,6 +2141,14 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
         &machine_info.name,
         presentation_types.machine.as_ref(),
     )?;
+    let machine_presentation_label =
+        optional_lit_str_tokens(machine_info.presentation.as_ref().and_then(|value| value.label.as_deref()));
+    let machine_presentation_description = optional_lit_str_tokens(
+        machine_info
+            .presentation
+            .as_ref()
+            .and_then(|value| value.description.as_deref()),
+    );
     let machine_meta_ty = presentation_type_tokens(presentation_types.machine.as_ref());
     let state_meta_ty = presentation_type_tokens(presentation_types.state.as_ref());
     let transition_meta_ty = presentation_type_tokens(presentation_types.transition.as_ref());
@@ -2200,6 +2219,14 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
                 )*
             };
 
+        static __STATUM_LINKED_STATES: &[statum::__private::LinkedStateDescriptor] = &[
+            #(#linked_state_entries),*
+        ];
+
+        static __STATUM_STATIC_MACHINE_LINKS: &[statum::__private::StaticMachineLinkDescriptor] = &[
+            #(#static_machine_link_entries),*
+        ];
+
         #[doc(hidden)]
         #[statum::__private::linkme::distributed_slice]
         #[linkme(crate = statum::__private::linkme)]
@@ -2212,12 +2239,21 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
             [statum::__private::TransitionPresentation<TransitionId, #transition_meta_ty>];
 
         #[doc(hidden)]
+        #[statum::__private::linkme::distributed_slice]
+        #[linkme(crate = statum::__private::linkme)]
+        pub static #linked_transition_slice_ident: [statum::__private::LinkedTransitionDescriptor];
+
+        #[doc(hidden)]
         #[allow(unused_imports)]
         pub use self::#transition_slice_ident as __STATUM_TRANSITIONS;
 
         #[doc(hidden)]
         #[allow(unused_imports)]
         pub use self::#transition_presentation_slice_ident as __STATUM_TRANSITION_PRESENTATIONS;
+
+        #[doc(hidden)]
+        #[allow(unused_imports)]
+        pub use self::#linked_transition_slice_ident as __STATUM_LINKED_TRANSITIONS;
 
         #[doc(hidden)]
         pub type __StatumTransitionPresentationMetadata = #transition_meta_ty;
@@ -2240,6 +2276,10 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
             &#transition_presentation_slice_ident
         }
 
+        fn __statum_linked_transitions() -> &'static [statum::__private::LinkedTransitionDescriptor] {
+            &#linked_transition_slice_ident
+        }
+
         pub static PRESENTATION: statum::__private::MachinePresentation<
             StateId,
             TransitionId,
@@ -2253,7 +2293,156 @@ fn generate_machine_module_introspection(machine_info: &MachineInfo) -> Result<T
                 __statum_transition_presentations,
             ),
         };
+
+        #[doc(hidden)]
+        #[statum::__private::linkme::distributed_slice(statum::__private::__STATUM_LINKED_MACHINES)]
+        #[linkme(crate = statum::__private::linkme)]
+        static __STATUM_LINKED_MACHINE: statum::__private::LinkedMachineGraph =
+            statum::__private::LinkedMachineGraph {
+                machine: statum::MachineDescriptor {
+                    module_path: #module_path,
+                    rust_type_path: #rust_type_path,
+                },
+                label: #machine_presentation_label,
+                description: #machine_presentation_description,
+                states: __STATUM_LINKED_STATES,
+                transitions: statum::__private::LinkedTransitionInventory::new(__statum_linked_transitions),
+                static_links: __STATUM_STATIC_MACHINE_LINKS,
+            };
     })
+}
+
+fn linked_state_entries(machine_info: &MachineInfo) -> Result<Vec<TokenStream>, TokenStream> {
+    let state_enum = machine_info.get_matching_state_enum()?;
+    state_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let rust_name = LitStr::new(&variant.name, Span::call_site());
+            let label = optional_lit_str_tokens(
+                variant
+                    .presentation
+                    .as_ref()
+                    .and_then(|value| value.label.as_deref()),
+            );
+            let description = optional_lit_str_tokens(
+                variant
+                    .presentation
+                    .as_ref()
+                    .and_then(|value| value.description.as_deref()),
+            );
+            let has_data = !matches!(variant.shape, crate::state::VariantShape::Unit);
+
+            Ok(quote! {
+                statum::__private::LinkedStateDescriptor {
+                    rust_name: #rust_name,
+                    label: #label,
+                    description: #description,
+                    has_data: #has_data,
+                }
+            })
+        })
+        .collect()
+}
+
+fn static_machine_link_entries(machine_info: &MachineInfo) -> Result<Vec<TokenStream>, TokenStream> {
+    let state_enum = machine_info.get_matching_state_enum()?;
+    let mut entries = Vec::new();
+
+    for variant in &state_enum.variants {
+        let from_state = LitStr::new(&variant.name, Span::call_site());
+        match variant.parse_shape()? {
+            crate::state::ParsedVariantShape::Unit => {}
+            crate::state::ParsedVariantShape::Tuple { data_type } => {
+                if let Some(candidate) = machine_link_candidate(data_type.as_ref()) {
+                    let machine_path = candidate.machine_path.iter().map(|segment| {
+                        let segment = LitStr::new(segment, Span::call_site());
+                        quote! { #segment }
+                    });
+                    let to_state = LitStr::new(&candidate.state_name, Span::call_site());
+                    entries.push(quote! {
+                        statum::__private::StaticMachineLinkDescriptor {
+                            from_state: #from_state,
+                            field_name: None,
+                            to_machine_path: &[#(#machine_path),*],
+                            to_state: #to_state,
+                        }
+                    });
+                }
+            }
+            crate::state::ParsedVariantShape::Named { fields, .. } => {
+                for field in fields {
+                    if let Some(candidate) = machine_link_candidate(&field.field_type) {
+                        let field_name = LitStr::new(&field.ident.to_string(), Span::call_site());
+                        let machine_path = candidate.machine_path.iter().map(|segment| {
+                            let segment = LitStr::new(segment, Span::call_site());
+                            quote! { #segment }
+                        });
+                        let to_state = LitStr::new(&candidate.state_name, Span::call_site());
+                        entries.push(quote! {
+                            statum::__private::StaticMachineLinkDescriptor {
+                                from_state: #from_state,
+                                field_name: Some(#field_name),
+                                to_machine_path: &[#(#machine_path),*],
+                                to_state: #to_state,
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
+struct MachineLinkCandidate {
+    machine_path: Vec<String>,
+    state_name: String,
+}
+
+fn machine_link_candidate(ty: &Type) -> Option<MachineLinkCandidate> {
+    let Type::Path(TypePath { qself: None, path }) = ty else {
+        return None;
+    };
+    let segment = path.segments.last()?;
+    let PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return None;
+    };
+    let target_state = arguments.args.iter().find_map(|argument| match argument {
+        GenericArgument::Type(ty) => machine_link_state_name(ty),
+        _ => None,
+    })?;
+    let machine_path = normalized_machine_path(path);
+    if machine_path.is_empty() {
+        return None;
+    }
+
+    Some(MachineLinkCandidate {
+        machine_path,
+        state_name: target_state,
+    })
+}
+
+fn machine_link_state_name(ty: &Type) -> Option<String> {
+    let Type::Path(TypePath { qself: None, path }) = ty else {
+        return None;
+    };
+    let segment = path.segments.last()?;
+    matches!(segment.arguments, PathArguments::None).then(|| segment.ident.to_string())
+}
+
+fn normalized_machine_path(path: &syn::Path) -> Vec<String> {
+    path.segments
+        .iter()
+        .skip_while(|segment| {
+            matches!(
+                segment.ident.to_string().as_str(),
+                "crate" | "self" | "super"
+            )
+        })
+        .map(|segment| segment.ident.to_string())
+        .collect()
 }
 
 fn generate_state_presentation_entry_macro(

--- a/statum-macros/src/machine/introspection.rs
+++ b/statum-macros/src/machine/introspection.rs
@@ -50,6 +50,18 @@ pub(crate) fn transition_presentation_slice_ident(
     )
 }
 
+pub(crate) fn linked_transition_slice_ident(
+    machine_name: &str,
+    file_path: Option<&str>,
+    line_number: usize,
+) -> Ident {
+    let key = format!(
+        "{machine_name}::linked::{}::{line_number}",
+        file_path.unwrap_or_default()
+    );
+    format_ident!("__STATUM_LINKED_TRANSITIONS_{:016X}", stable_hash(&key))
+}
+
 fn stable_hash(input: &str) -> u64 {
     let mut hash = 0xcbf29ce484222325u64;
     for byte in input.as_bytes() {
@@ -62,7 +74,8 @@ fn stable_hash(input: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        to_shouty_snake_identifier, transition_presentation_slice_ident, transition_slice_ident,
+        linked_transition_slice_ident, to_shouty_snake_identifier,
+        transition_presentation_slice_ident, transition_slice_ident,
     };
 
     #[test]
@@ -97,6 +110,22 @@ mod tests {
         assert!(first.starts_with("__STATUM_TRANSITION_PRESENTATION_"));
         assert!(second.starts_with("__STATUM_TRANSITION_PRESENTATION_"));
         assert!(third.starts_with("__STATUM_TRANSITION_PRESENTATION_"));
+        assert_ne!(first, second);
+        assert_ne!(first, third);
+    }
+
+    #[test]
+    fn linked_transition_slice_ident_tracks_machine_source() {
+        let first = linked_transition_slice_ident("ReviewFlow", Some("src/alpha.rs"), 40)
+            .to_string();
+        let second = linked_transition_slice_ident("ReviewFlow", Some("src/beta.rs"), 40)
+            .to_string();
+        let third = linked_transition_slice_ident("ReviewFlow", Some("src/alpha.rs"), 91)
+            .to_string();
+
+        assert!(first.starts_with("__STATUM_LINKED_TRANSITIONS_"));
+        assert!(second.starts_with("__STATUM_LINKED_TRANSITIONS_"));
+        assert!(third.starts_with("__STATUM_LINKED_TRANSITIONS_"));
         assert_ne!(first, second);
         assert_ne!(first, third);
     }

--- a/statum-macros/src/machine/mod.rs
+++ b/statum-macros/src/machine/mod.rs
@@ -11,7 +11,8 @@ pub(crate) use generics::{
     machine_type_with_state,
 };
 pub(crate) use introspection::{
-    to_shouty_snake_identifier, transition_presentation_slice_ident, transition_slice_ident,
+    linked_transition_slice_ident, to_shouty_snake_identifier,
+    transition_presentation_slice_ident, transition_slice_ident,
 };
 pub use metadata::{MachineInfo, MachinePath};
 pub use registry::{

--- a/statum-macros/src/machine/mod.rs
+++ b/statum-macros/src/machine/mod.rs
@@ -17,6 +17,6 @@ pub(crate) use introspection::{
 pub use metadata::{MachineInfo, MachinePath};
 pub use registry::{
     LoadedMachineLookupFailure, format_loaded_machine_candidates, lookup_loaded_machine_in_module,
-    store_machine_struct,
+    same_named_loaded_machines_elsewhere, store_machine_struct,
 };
 pub use validation::{invalid_machine_target_error, validate_machine_struct};

--- a/statum-macros/src/machine/registry.rs
+++ b/statum-macros/src/machine/registry.rs
@@ -86,6 +86,15 @@ pub fn lookup_loaded_machine_in_module(
     }))
 }
 
+pub fn same_named_loaded_machines_elsewhere(
+    machine_path: &MachinePath,
+    machine_name: &str,
+) -> Vec<MachineInfo> {
+    loaded_machine_candidates_matching(|machine| {
+        machine.name == machine_name && machine.module_path.as_ref() != machine_path.as_ref()
+    })
+}
+
 pub fn format_loaded_machine_candidates(candidates: &[MachineInfo]) -> String {
     candidates
         .iter()

--- a/statum-macros/src/transition.rs
+++ b/statum-macros/src/transition.rs
@@ -298,15 +298,36 @@ pub fn generate_transition_impl(
         let token_ident = format_ident!("__STATUM_TRANSITION_TOKEN_{}", unique_suffix);
         let targets_ident = format_ident!("__STATUM_TRANSITION_TARGETS_{}", unique_suffix);
         let registration_ident = format_ident!("__STATUM_TRANSITION_SITE_{}", unique_suffix);
+        let linked_registration_ident =
+            format_ident!("__STATUM_LINKED_TRANSITION_SITE_{}", unique_suffix);
         let id_const_ident = format_ident!(
             "{}",
             to_shouty_snake_identifier(&function.name.to_string())
         );
         let method_name = LitStr::new(&function.name.to_string(), function.name.span());
         let source_state_ident = format_ident!("{}", tr_impl.source_state);
+        let source_state_name = LitStr::new(&tr_impl.source_state, function.name.span());
+        let linked_label = optional_lit_str_tokens(
+            function
+                .presentation
+                .as_ref()
+                .and_then(|value| value.label.as_deref()),
+            function.name.span(),
+        );
+        let linked_description = optional_lit_str_tokens(
+            function
+                .presentation
+                .as_ref()
+                .and_then(|value| value.description.as_deref()),
+            function.name.span(),
+        );
         let target_state_idents = return_states.iter().map(|state| {
             let state_ident = format_ident!("{}", state);
             quote! { #machine_module_path::StateId::#state_ident }
+        });
+        let target_state_names = return_states.iter().map(|state| {
+            let state = LitStr::new(state, function.name.span());
+            quote! { #state }
         });
         let target_state_count = return_states.len();
         let cfg_attrs = propagated_cfg_attrs(&tr_impl.attrs, &function.attrs);
@@ -331,6 +352,18 @@ pub fn generate_transition_impl(
                     method_name: #method_name,
                     from: #machine_module_path::StateId::#source_state_ident,
                     to: &#targets_ident,
+                };
+
+            #(#cfg_attrs)*
+            #[statum::__private::linkme::distributed_slice(#machine_module_path::__STATUM_LINKED_TRANSITIONS)]
+            #[linkme(crate = statum::__private::linkme)]
+            static #linked_registration_ident: statum::__private::LinkedTransitionDescriptor =
+                statum::__private::LinkedTransitionDescriptor {
+                    method_name: #method_name,
+                    label: #linked_label,
+                    description: #linked_description,
+                    from: #source_state_name,
+                    to: &[#(#target_state_names),*],
                 };
 
             #(#cfg_attrs)*

--- a/statum-macros/src/validators.rs
+++ b/statum-macros/src/validators.rs
@@ -19,6 +19,7 @@ use signatures::{
 
 pub(super) struct ValidatorMethodSpec {
     pub(super) validator_ident: Ident,
+    pub(super) variant_name: String,
     pub(super) actual_ok_type: Type,
     pub(super) return_kind: ValidatorReturnKind,
     pub(super) is_async: bool,
@@ -31,7 +32,12 @@ struct CollectValidatorContext<'a> {
     machine_fields: Option<&'a [Ident]>,
 }
 
-pub fn parse_validators(attr: TokenStream, item: TokenStream, module_path: &str) -> TokenStream {
+pub fn parse_validators(
+    attr: TokenStream,
+    item: TokenStream,
+    module_path: &str,
+    line_number: usize,
+) -> TokenStream {
     let machine_ident = parse_macro_input!(attr as Ident);
     let item_impl = parse_macro_input!(item as ItemImpl);
     let struct_ident = &item_impl.self_ty;
@@ -117,6 +123,51 @@ pub fn parse_validators(attr: TokenStream, item: TokenStream, module_path: &str)
         "__statum_emit_{}_validator_report_variant",
         crate::to_snake_case(&machine_name)
     );
+    let machine_module_path = syn::LitStr::new(
+        diagnostic_machine.module_path.as_ref(),
+        proc_macro2::Span::call_site(),
+    );
+    let machine_rust_type_path = syn::LitStr::new(
+        &format!("{}::{}", diagnostic_machine.module_path, machine_name),
+        proc_macro2::Span::call_site(),
+    );
+    let linked_validator_registration_ident = linked_validator_registration_ident(
+        &machine_name,
+        module_path,
+        &persisted_type_display,
+        line_number,
+    );
+    let linked_validator_targets_ident = linked_validator_targets_ident(
+        &machine_name,
+        module_path,
+        &persisted_type_display,
+        line_number,
+    );
+    let source_module_path = syn::LitStr::new(module_path, proc_macro2::Span::call_site());
+    let source_type_display =
+        syn::LitStr::new(&persisted_type_display, proc_macro2::Span::call_site());
+    let validator_target_states = validator_methods
+        .iter()
+        .map(|method| syn::LitStr::new(&method.variant_name, proc_macro2::Span::call_site()))
+        .collect::<Vec<_>>();
+    let linked_validator_registration = quote! {
+        #[doc(hidden)]
+        static #linked_validator_targets_ident: &[&str] = &[#(#validator_target_states),*];
+
+        #[doc(hidden)]
+        #[statum::__private::linkme::distributed_slice(statum::__private::__STATUM_LINKED_VALIDATOR_ENTRIES)]
+        #[linkme(crate = statum::__private::linkme)]
+        static #linked_validator_registration_ident: statum::__private::LinkedValidatorEntryDescriptor =
+            statum::__private::LinkedValidatorEntryDescriptor {
+                machine: statum::MachineDescriptor {
+                    module_path: #machine_module_path,
+                    rust_type_path: #machine_rust_type_path,
+                },
+                source_module_path: #source_module_path,
+                source_type_display: #source_type_display,
+                target_states: #linked_validator_targets_ident,
+            };
+    };
     let async_mode = if validator_methods.iter().any(|method| method.is_async) {
         quote! { true }
     } else {
@@ -138,6 +189,7 @@ pub fn parse_validators(attr: TokenStream, item: TokenStream, module_path: &str)
         #passthrough_impl
         #build_variant_macro
         #report_variant_macro
+        #linked_validator_registration
         #validator_support_macro_ident! {
             persisted = #struct_ident,
             build_variant = #build_variant_macro_ident,
@@ -169,6 +221,17 @@ fn collect_validator_methods(
         let Some(state_name) = validator_state_name_from_ident(&func.sig.ident) else {
             continue;
         };
+        if let Some(attr_name) = cfg_like_attr_name(&func.attrs) {
+            let message = format!(
+                "Error: `#[validators({})]` on `impl {}` method `{}` uses `#[{}]`, but Statum does not support conditionally compiled validator methods.\nFix: move the cfg gate to the whole `#[validators({})]` impl or split cfg-specific rebuild surfaces into separate impls.",
+                context.machine_name,
+                context.persisted_type_display,
+                func.sig.ident,
+                attr_name,
+                context.machine_name,
+            );
+            return Err(syn::Error::new_spanned(func, message).to_compile_error());
+        }
         let diagnostic_context = ValidatorDiagnosticContext {
             persisted_type_display: context.persisted_type_display,
             machine_name: context.machine_name,
@@ -181,8 +244,10 @@ fn collect_validator_methods(
             ok_type,
             return_kind,
         } = analyze_validator_return_type(func, &diagnostic_context)?;
+        let variant_name = state_name_to_variant_name(&state_name);
         methods.push(ValidatorMethodSpec {
             validator_ident: func.sig.ident.clone(),
+            variant_name,
             actual_ok_type: ok_type,
             return_kind,
             is_async: func.sig.asyncness.is_some(),
@@ -202,6 +267,54 @@ fn state_name_to_variant_name(state_name: &str) -> String {
         }
     }
     result
+}
+
+fn cfg_like_attr_name(attrs: &[syn::Attribute]) -> Option<&'static str> {
+    attrs.iter().find_map(|attr| {
+        if attr.path().is_ident("cfg") {
+            Some("cfg")
+        } else if attr.path().is_ident("cfg_attr") {
+            Some("cfg_attr")
+        } else {
+            None
+        }
+    })
+}
+
+fn linked_validator_registration_ident(
+    machine_name: &str,
+    module_path: &str,
+    persisted_type_display: &str,
+    line_number: usize,
+) -> Ident {
+    let key = format!(
+        "{machine_name}::validator-entry::{module_path}::{persisted_type_display}::{line_number}"
+    );
+    format_ident!("__STATUM_LINKED_VALIDATOR_ENTRY_{:016X}", stable_hash(&key))
+}
+
+fn linked_validator_targets_ident(
+    machine_name: &str,
+    module_path: &str,
+    persisted_type_display: &str,
+    line_number: usize,
+) -> Ident {
+    let key = format!(
+        "{machine_name}::validator-targets::{module_path}::{persisted_type_display}::{line_number}"
+    );
+    format_ident!(
+        "__STATUM_LINKED_VALIDATOR_TARGETS_{:016X}",
+        stable_hash(&key)
+    )
+}
+
+fn stable_hash(input: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 fn generate_empty_validator_methods_error(

--- a/statum-macros/src/validators/resolution.rs
+++ b/statum-macros/src/validators/resolution.rs
@@ -7,7 +7,7 @@ use macro_registry::query;
 
 use crate::{
     LoadedMachineLookupFailure, MachineInfo, MachinePath, format_loaded_machine_candidates,
-    lookup_loaded_machine_in_module,
+    lookup_loaded_machine_in_module, same_named_loaded_machines_elsewhere,
 };
 
 pub(super) fn resolve_machine_metadata(
@@ -19,6 +19,9 @@ pub(super) fn resolve_machine_metadata(
     lookup_loaded_machine_in_module(&module_path_key, &machine_name).map_err(|failure| {
         let current_line = current_source_info().map(|(_, line)| line).unwrap_or_default();
         let available = available_machine_candidates_in_module(module_path);
+        let same_named_elsewhere = same_named_machine_candidates_elsewhere(&machine_name, module_path);
+        let loaded_same_named_elsewhere =
+            same_named_loaded_machines_elsewhere(&module_path_key, &machine_name);
         let suggested_machine_name = available
             .first()
             .map(|candidate| candidate.name.as_str())
@@ -44,14 +47,31 @@ pub(super) fn resolve_machine_metadata(
             })
             .map(|line| format!("{line}\n"))
             .unwrap_or_default();
-        let elsewhere_line = same_named_machine_candidates_elsewhere(&machine_name, module_path)
+        let elsewhere_line = same_named_elsewhere
+            .as_ref()
             .map(|candidates| {
                 format!(
                     "Same-named `#[machine]` items elsewhere in this file: {}.",
-                    query::format_candidates(&candidates)
+                    query::format_candidates(candidates)
                 )
             })
             .unwrap_or_else(|| "No same-named `#[machine]` items were found in other modules of this file.".to_string());
+        let loaded_elsewhere_line = if loaded_same_named_elsewhere.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\nLoaded same-named `#[machine]` items elsewhere in this crate: {}.",
+                format_loaded_machine_candidates(&loaded_same_named_elsewhere)
+            )
+        };
+        let include_line = if available.is_empty()
+            && same_named_elsewhere.is_none()
+            && !loaded_same_named_elsewhere.is_empty()
+        {
+            "\nIf this `#[validators]` impl comes from an `include!()` file, Statum does not currently resolve enclosing-module `#[machine]` items from that file. Move the impl inline or into the module source file.".to_string()
+        } else {
+            String::new()
+        };
         let missing_attr_line = plain_struct_line_in_module(module_path, &machine_name).map(|line| {
             format!(
                 "A struct named `{machine_name}` exists on line {line}, but it is not annotated with `#[machine]`."
@@ -67,7 +87,7 @@ pub(super) fn resolve_machine_metadata(
             ),
         };
         let message = format!(
-            "Error: no resolved `#[machine]` named `{machine_name}` was found in module `{module_path}`.\n{authority_line}\n{ordering_line}{}\n{elsewhere_line}\n{available_line}\nHelp: point `#[validators(...)]` at the Statum machine type in this module and declare that `#[machine]` item before this validators impl.\nCorrect shape: `#[validators({suggested_machine_name})] impl PersistedRow {{ ... }}` where `{suggested_machine_name}` is declared with `#[machine]` in `{module_path}`.",
+            "Error: no resolved `#[machine]` named `{machine_name}` was found in module `{module_path}`.\n{authority_line}\n{ordering_line}{}\n{elsewhere_line}{loaded_elsewhere_line}{include_line}\n{available_line}\nHelp: point `#[validators(...)]` at the Statum machine type in this module and declare that `#[machine]` item before this validators impl.\nCorrect shape: `#[validators({suggested_machine_name})] impl PersistedRow {{ ... }}` where `{suggested_machine_name}` is declared with `#[machine]` in `{module_path}`.",
             missing_attr_line.unwrap_or_else(|| "No plain struct with that name was found in this module either.".to_string()),
         );
         quote! {

--- a/statum-macros/tests/macro_errors.rs
+++ b/statum-macros/tests/macro_errors.rs
@@ -1,3 +1,42 @@
+use std::process::Command;
+use std::sync::OnceLock;
+
+fn uses_rust_1_93_trybuild_fixtures() -> bool {
+    static USES_RUST_1_93_FIXTURES: OnceLock<bool> = OnceLock::new();
+
+    *USES_RUST_1_93_FIXTURES.get_or_init(|| {
+        let output = match Command::new("rustc").arg("--version").output() {
+            Ok(output) => output,
+            Err(_) => return false,
+        };
+        let stdout = match String::from_utf8(output.stdout) {
+            Ok(stdout) => stdout,
+            Err(_) => return false,
+        };
+        let mut parts = stdout.split_whitespace();
+        let _binary = parts.next();
+        let version = match parts.next() {
+            Some(version) => version,
+            None => return false,
+        };
+        let mut semver = version.split('.');
+        let _major = semver.next();
+        matches!(semver.next(), Some("93"))
+    })
+}
+
+fn compile_fail_with_rust_1_93_fixture(
+    t: &trybuild::TestCases,
+    default_fixture: &str,
+    rust_1_93_fixture: &str,
+) {
+    if uses_rust_1_93_trybuild_fixtures() {
+        t.compile_fail(rust_1_93_fixture);
+    } else {
+        t.compile_fail(default_fixture);
+    }
+}
+
 #[test]
 fn test_invalid_state_usage() {
     let t = trybuild::TestCases::new();
@@ -34,8 +73,16 @@ fn test_invalid_transition_usage() {
     t.compile_fail("tests/ui/invalid_transition_not_method.rs");
     t.compile_fail("tests/ui/invalid_transition_wrong_return.rs");
     t.compile_fail("tests/ui/invalid_transition_conditional.rs");
-    t.compile_fail("tests/ui/invalid_transition_unknown_machine.rs");
-    t.compile_fail("tests/ui/invalid_transition_plain_struct_machine_name.rs");
+    compile_fail_with_rust_1_93_fixture(
+        &t,
+        "tests/ui/invalid_transition_unknown_machine.rs",
+        "tests/ui/invalid_transition_unknown_machine_rust_1_93.rs",
+    );
+    compile_fail_with_rust_1_93_fixture(
+        &t,
+        "tests/ui/invalid_transition_plain_struct_machine_name.rs",
+        "tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs",
+    );
     t.compile_fail("tests/ui/invalid_transition_unknown_source_state.rs");
     t.compile_fail("tests/ui/invalid_transition_unknown_return_state.rs");
     t.compile_fail("tests/ui/invalid_transition_unknown_secondary_return_state.rs");
@@ -64,6 +111,7 @@ fn test_invalid_validators_usage() {
     t.compile_fail("tests/ui/invalid_validators_plain_struct_machine_name.rs");
     t.compile_fail("tests/ui/invalid_validators_parameter_name_collision.rs");
     t.compile_fail("tests/ui/invalid_validators_declared_before_machine.rs");
+    t.compile_fail("tests/ui/invalid_validators_include_impl.rs");
     t.compile_fail("tests/ui/invalid_validators_cfg_method.rs");
     t.compile_fail("tests/ui/invalid_validators_cfg_attr_method.rs");
     t.compile_fail("tests/ui/invalid_legacy_superstate.rs");

--- a/statum-macros/tests/macro_errors.rs
+++ b/statum-macros/tests/macro_errors.rs
@@ -64,6 +64,8 @@ fn test_invalid_validators_usage() {
     t.compile_fail("tests/ui/invalid_validators_plain_struct_machine_name.rs");
     t.compile_fail("tests/ui/invalid_validators_parameter_name_collision.rs");
     t.compile_fail("tests/ui/invalid_validators_declared_before_machine.rs");
+    t.compile_fail("tests/ui/invalid_validators_cfg_method.rs");
+    t.compile_fail("tests/ui/invalid_validators_cfg_attr_method.rs");
     t.compile_fail("tests/ui/invalid_legacy_superstate.rs");
     t.compile_fail("tests/ui/invalid_legacy_machine_builder.rs");
     t.compile_fail("tests/ui/invalid_legacy_machines_builder.rs");

--- a/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name.stderr
+++ b/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name.stderr
@@ -27,10 +27,12 @@ error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mac
   --> tests/ui/invalid_transition_plain_struct_machine_name.rs:23:1
    |
 23 | #[transition]
-   | ^^^^^^^^^^^^^
-   | |
-   | use of unresolved module or unlinked crate `machine`
-   | help: a struct with a similar name exists: `Machine`
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `machine`
    |
    = help: if you wanted to use a crate named `machine`, use `cargo add machine` to add it to your `Cargo.toml`
    = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a struct with a similar name exists
+   |
+23 - #[transition]
+23 + Machine
+   |

--- a/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name.stderr
+++ b/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name.stderr
@@ -27,12 +27,10 @@ error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mac
   --> tests/ui/invalid_transition_plain_struct_machine_name.rs:23:1
    |
 23 | #[transition]
-   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `machine`
+   | ^^^^^^^^^^^^^
+   | |
+   | use of unresolved module or unlinked crate `machine`
+   | help: a struct with a similar name exists: `Machine`
    |
    = help: if you wanted to use a crate named `machine`, use `cargo add machine` to add it to your `Cargo.toml`
    = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: a struct with a similar name exists
-   |
-23 - #[transition]
-23 + Machine
-   |

--- a/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs
+++ b/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs
@@ -1,0 +1,29 @@
+#![allow(unused_imports)]
+extern crate self as statum;
+pub use statum_macros::__statum_emit_validator_methods_impl;
+pub use statum_core::__private;
+pub use statum_core::TransitionInventory;
+pub use statum_core::{
+    CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error, MachineDescriptor,
+    MachineGraph, MachineIntrospection, MachineStateIdentity, RebuildAttempt, RebuildReport,
+    StateDescriptor, StateMarker, TransitionDescriptor, UnitState,
+};
+
+use statum_macros::{state, transition};
+
+#[state]
+enum State {
+    A,
+    B,
+}
+
+struct Machine<State>(core::marker::PhantomData<State>);
+
+#[transition]
+impl Machine<A> {
+    fn to_b(self) -> Machine<B> {
+        Machine(core::marker::PhantomData)
+    }
+}
+
+fn main() {}

--- a/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.stderr
+++ b/statum-macros/tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.stderr
@@ -1,0 +1,36 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `machine`
+  --> tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs:22:1
+   |
+22 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `machine`
+   |
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot find macro `__statum_resolve_machine_transition_target` in this scope
+  --> tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs:22:1
+   |
+22 | #[transition]
+   | ^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `machine`
+  --> tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs:22:1
+   |
+22 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `machine`
+   |
+   = help: if you wanted to use a crate named `machine`, use `cargo add machine` to add it to your `Cargo.toml`
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `machine`
+  --> tests/ui/invalid_transition_plain_struct_machine_name_rust_1_93.rs:22:1
+   |
+22 | #[transition]
+   | ^^^^^^^^^^^^^
+   | |
+   | use of unresolved module or unlinked crate `machine`
+   | help: a struct with a similar name exists: `Machine`
+   |
+   = help: if you wanted to use a crate named `machine`, use `cargo add machine` to add it to your `Cargo.toml`
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/statum-macros/tests/ui/invalid_transition_unknown_machine.stderr
+++ b/statum-macros/tests/ui/invalid_transition_unknown_machine.stderr
@@ -13,9 +13,14 @@ error: cannot find macro `__statum_resolve_does_not_exist_transition_target` in 
    | ---------- similarly named macro `__statum_resolve_machine_transition_target` defined here
 ...
 26 | #[transition]
-   | ^^^^^^^^^^^^^ help: a macro with a similar name exists: `__statum_resolve_machine_transition_target`
+   | ^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a macro with a similar name exists
+   |
+26 - #[transition]
+26 + __statum_resolve_machine_transition_target
+   |
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
   --> tests/ui/invalid_transition_unknown_machine.rs:26:1

--- a/statum-macros/tests/ui/invalid_transition_unknown_machine.stderr
+++ b/statum-macros/tests/ui/invalid_transition_unknown_machine.stderr
@@ -13,14 +13,9 @@ error: cannot find macro `__statum_resolve_does_not_exist_transition_target` in 
    | ---------- similarly named macro `__statum_resolve_machine_transition_target` defined here
 ...
 26 | #[transition]
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^ help: a macro with a similar name exists: `__statum_resolve_machine_transition_target`
    |
    = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: a macro with a similar name exists
-   |
-26 - #[transition]
-26 + __statum_resolve_machine_transition_target
-   |
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
   --> tests/ui/invalid_transition_unknown_machine.rs:26:1

--- a/statum-macros/tests/ui/invalid_transition_unknown_machine_rust_1_93.rs
+++ b/statum-macros/tests/ui/invalid_transition_unknown_machine_rust_1_93.rs
@@ -1,0 +1,32 @@
+#![allow(unused_imports)]
+extern crate self as statum;
+pub use statum_macros::__statum_emit_validator_methods_impl;
+pub use statum_core::__private;
+pub use statum_core::TransitionInventory;
+pub use statum_core::{
+    CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error, MachineDescriptor,
+    MachineGraph, MachineIntrospection, MachineStateIdentity, RebuildAttempt, RebuildReport,
+    StateDescriptor, StateMarker, TransitionDescriptor, UnitState,
+};
+
+use statum_macros::{machine, state, transition};
+
+#[state]
+enum State {
+    A,
+    B,
+}
+
+#[machine]
+struct Machine<State> {}
+
+struct DoesNotExist<S>(core::marker::PhantomData<S>);
+
+#[transition]
+impl DoesNotExist<A> {
+    fn to_b(self) -> DoesNotExist<B> {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/statum-macros/tests/ui/invalid_transition_unknown_machine_rust_1_93.stderr
+++ b/statum-macros/tests/ui/invalid_transition_unknown_machine_rust_1_93.stderr
@@ -1,0 +1,53 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
+  --> tests/ui/invalid_transition_unknown_machine_rust_1_93.rs:25:1
+   |
+25 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `does_not_exist`
+   |
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot find macro `__statum_resolve_does_not_exist_transition_target` in this scope
+  --> tests/ui/invalid_transition_unknown_machine_rust_1_93.rs:25:1
+   |
+20 | #[machine]
+   | ---------- similarly named macro `__statum_resolve_machine_transition_target` defined here
+...
+25 | #[transition]
+   | ^^^^^^^^^^^^^ help: a macro with a similar name exists: `__statum_resolve_machine_transition_target`
+   |
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
+  --> tests/ui/invalid_transition_unknown_machine_rust_1_93.rs:25:1
+   |
+25 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `does_not_exist`
+   |
+   = help: if you wanted to use a crate named `does_not_exist`, use `cargo add does_not_exist` to add it to your `Cargo.toml`
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+ 3 + use crate::machine::StateId;
+   |
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
+  --> tests/ui/invalid_transition_unknown_machine_rust_1_93.rs:25:1
+   |
+25 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `does_not_exist`
+   |
+   = help: if you wanted to use a crate named `does_not_exist`, use `cargo add does_not_exist` to add it to your `Cargo.toml`
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct
+   |
+ 3 + use crate::machine::TransitionId;
+   |
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does_not_exist`
+  --> tests/ui/invalid_transition_unknown_machine_rust_1_93.rs:25:1
+   |
+25 | #[transition]
+   | ^^^^^^^^^^^^^ use of unresolved module or unlinked crate `does_not_exist`
+   |
+   = help: if you wanted to use a crate named `does_not_exist`, use `cargo add does_not_exist` to add it to your `Cargo.toml`
+   = note: this error originates in the attribute macro `transition` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/statum-macros/tests/ui/invalid_validators_cfg_attr_method.rs
+++ b/statum-macros/tests/ui/invalid_validators_cfg_attr_method.rs
@@ -1,0 +1,45 @@
+#![allow(unused_imports)]
+extern crate self as statum;
+pub use statum_core::__private;
+pub use statum_core::TransitionInventory;
+pub use statum_core::{
+    CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error, MachineDescriptor,
+    MachineGraph, MachineIntrospection, MachineStateIdentity, RebuildAttempt, RebuildReport,
+    StateDescriptor, StateMarker, TransitionDescriptor, UnitState,
+};
+pub use statum_macros::__statum_emit_validator_methods_impl;
+
+use statum_macros::{machine, state, validators};
+
+#[state]
+enum TaskState {
+    Draft,
+    Published,
+}
+
+#[machine]
+struct TaskMachine<TaskState> {}
+
+struct DbRow {
+    status: &'static str,
+}
+
+#[validators(TaskMachine)]
+impl DbRow {
+    fn is_draft(&self) -> statum::Result<()> {
+        if self.status == "draft" {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+
+    #[cfg_attr(any(), cfg(any()))]
+    fn is_published(&self) -> statum::Result<()> {
+        if self.status == "published" {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+}

--- a/statum-macros/tests/ui/invalid_validators_cfg_attr_method.stderr
+++ b/statum-macros/tests/ui/invalid_validators_cfg_attr_method.stderr
@@ -1,0 +1,17 @@
+error: Error: `#[validators(TaskMachine)]` on `impl DbRow` method `is_published` uses `#[cfg_attr]`, but Statum does not support conditionally compiled validator methods.
+       Fix: move the cfg gate to the whole `#[validators(TaskMachine)]` impl or split cfg-specific rebuild surfaces into separate impls.
+  --> tests/ui/invalid_validators_cfg_attr_method.rs:37:5
+   |
+37 | /     #[cfg_attr(any(), cfg(any()))]
+38 | |     fn is_published(&self) -> statum::Result<()> {
+39 | |         if self.status == "published" {
+40 | |             Ok(())
+...  |
+44 | |     }
+   | |_____^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui/invalid_validators_cfg_attr_method.rs:45:2
+   |
+45 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_validators_cfg_attr_method.rs`

--- a/statum-macros/tests/ui/invalid_validators_cfg_method.rs
+++ b/statum-macros/tests/ui/invalid_validators_cfg_method.rs
@@ -1,0 +1,45 @@
+#![allow(unused_imports)]
+extern crate self as statum;
+pub use statum_core::__private;
+pub use statum_core::TransitionInventory;
+pub use statum_core::{
+    CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error, MachineDescriptor,
+    MachineGraph, MachineIntrospection, MachineStateIdentity, RebuildAttempt, RebuildReport,
+    StateDescriptor, StateMarker, TransitionDescriptor, UnitState,
+};
+pub use statum_macros::__statum_emit_validator_methods_impl;
+
+use statum_macros::{machine, state, validators};
+
+#[state]
+enum TaskState {
+    Draft,
+    Published,
+}
+
+#[machine]
+struct TaskMachine<TaskState> {}
+
+struct DbRow {
+    status: &'static str,
+}
+
+#[validators(TaskMachine)]
+impl DbRow {
+    fn is_draft(&self) -> statum::Result<()> {
+        if self.status == "draft" {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+
+    #[cfg(any())]
+    fn is_published(&self) -> statum::Result<()> {
+        if self.status == "published" {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+}

--- a/statum-macros/tests/ui/invalid_validators_cfg_method.stderr
+++ b/statum-macros/tests/ui/invalid_validators_cfg_method.stderr
@@ -1,0 +1,17 @@
+error: Error: `#[validators(TaskMachine)]` on `impl DbRow` method `is_published` uses `#[cfg]`, but Statum does not support conditionally compiled validator methods.
+       Fix: move the cfg gate to the whole `#[validators(TaskMachine)]` impl or split cfg-specific rebuild surfaces into separate impls.
+  --> tests/ui/invalid_validators_cfg_method.rs:37:5
+   |
+37 | /     #[cfg(any())]
+38 | |     fn is_published(&self) -> statum::Result<()> {
+39 | |         if self.status == "published" {
+40 | |             Ok(())
+...  |
+44 | |     }
+   | |_____^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui/invalid_validators_cfg_method.rs:45:2
+   |
+45 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_validators_cfg_method.rs`

--- a/statum-macros/tests/ui/invalid_validators_include_impl.rs
+++ b/statum-macros/tests/ui/invalid_validators_include_impl.rs
@@ -1,0 +1,28 @@
+#![allow(unused_imports)]
+extern crate self as statum;
+pub use statum_core::__private;
+pub use statum_core::TransitionInventory;
+pub use statum_core::{
+    CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error, MachineDescriptor,
+    MachineGraph, MachineIntrospection, MachineStateIdentity, RebuildAttempt, RebuildReport,
+    StateDescriptor, StateMarker, TransitionDescriptor, UnitState,
+};
+pub use statum_macros::__statum_emit_validator_methods_impl;
+
+use statum_macros::{machine, state};
+
+mod alpha {
+    use super::*;
+    use statum_macros::validators;
+
+    #[state]
+    enum TaskState {
+        Draft,
+        Done,
+    }
+
+    #[machine]
+    struct TaskMachine<TaskState> {}
+
+    include!("support/invalid_validators_include_impl_item.rs");
+}

--- a/statum-macros/tests/ui/invalid_validators_include_impl.stderr
+++ b/statum-macros/tests/ui/invalid_validators_include_impl.stderr
@@ -1,0 +1,21 @@
+error: Error: no resolved `#[machine]` named `TaskMachine` was found in module `invalid_validators_include_impl_item`.
+       Statum only resolves `#[machine]` items that have already expanded before this `#[validators]` impl.
+       No plain struct with that name was found in this module either.
+       No same-named `#[machine]` items were found in other modules of this file.
+       Loaded same-named `#[machine]` items elsewhere in this crate: `TaskMachine` in `invalid_validators_include_impl::alpha` ($DIR/tests/ui/invalid_validators_include_impl.rs:25).
+       If this `#[validators]` impl comes from an `include!()` file, Statum does not currently resolve enclosing-module `#[machine]` items from that file. Move the impl inline or into the module source file.
+       No `#[machine]` items were found in this module.
+       Help: point `#[validators(...)]` at the Statum machine type in this module and declare that `#[machine]` item before this validators impl.
+       Correct shape: `#[validators(TaskMachine)] impl PersistedRow { ... }` where `TaskMachine` is declared with `#[machine]` in `invalid_validators_include_impl_item`.
+ --> tests/ui/support/invalid_validators_include_impl_item.rs
+  |
+  | #[validators(TaskMachine)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `validators` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui/invalid_validators_include_impl.rs:28:2
+   |
+28 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_validators_include_impl.rs`

--- a/statum-macros/tests/ui/support/invalid_validators_include_impl_item.rs
+++ b/statum-macros/tests/ui/support/invalid_validators_include_impl_item.rs
@@ -1,0 +1,22 @@
+struct DbRow {
+    done: bool,
+}
+
+#[validators(TaskMachine)]
+impl DbRow {
+    fn is_draft(&self) -> Result<(), statum_core::Error> {
+        if !self.done {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+
+    fn is_done(&self) -> Result<(), statum_core::Error> {
+        if self.done {
+            Ok(())
+        } else {
+            Err(statum_core::Error::InvalidState)
+        }
+    }
+}

--- a/statum/src/lib.rs
+++ b/statum/src/lib.rs
@@ -277,11 +277,13 @@ pub use statum_core::__private;
 pub use statum_core::projection;
 #[doc(inline)]
 pub use statum_core::{
-    Branch, CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState, Error,
-    MachineDescriptor, MachineGraph, MachineIntrospection, MachinePresentation,
-    MachinePresentationDescriptor, MachineStateIdentity, MachineTransitionRecorder, RebuildAttempt,
-    RebuildReport, RecordedTransition, Rejection, Result, StateDescriptor, StateMarker,
-    StatePresentation, TransitionDescriptor, TransitionInventory, TransitionPresentation,
+    linked_machines, Branch, CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState,
+    Error, LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
+    LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
+    MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
+    MachineTransitionRecorder, RebuildAttempt, RebuildReport, RecordedTransition, Rejection,
+    Result, StateDescriptor, StateMarker, StatePresentation, StaticMachineLinkDescriptor,
+    TransitionDescriptor, TransitionInventory, TransitionPresentation,
     TransitionPresentationInventory, UnitState, Validation,
 };
 

--- a/statum/src/lib.rs
+++ b/statum/src/lib.rs
@@ -421,7 +421,8 @@ pub use statum_macros::__statum_emit_validator_methods_impl;
 /// Machine fields are available by name inside validator bodies through
 /// generated bindings. Persisted-row fields still live on `self`. Put `#[cfg]`
 /// or `#[cfg_attr]` on the whole `#[validators]` impl, not on individual
-/// `is_{state}` methods.
+/// `is_{state}` methods. Validator impls inside `include!()` files are
+/// rejected; keep them inline or in the module source file.
 ///
 /// ```rust
 /// use statum::{machine, state, validators, Error};

--- a/statum/src/lib.rs
+++ b/statum/src/lib.rs
@@ -277,14 +277,14 @@ pub use statum_core::__private;
 pub use statum_core::projection;
 #[doc(inline)]
 pub use statum_core::{
-    linked_machines, Branch, CanTransitionMap, CanTransitionTo, CanTransitionWith, DataState,
-    Error, LinkedMachineGraph, LinkedStateDescriptor, LinkedTransitionDescriptor,
-    LinkedTransitionInventory, MachineDescriptor, MachineGraph, MachineIntrospection,
-    MachinePresentation, MachinePresentationDescriptor, MachineStateIdentity,
-    MachineTransitionRecorder, RebuildAttempt, RebuildReport, RecordedTransition, Rejection,
-    Result, StateDescriptor, StateMarker, StatePresentation, StaticMachineLinkDescriptor,
-    TransitionDescriptor, TransitionInventory, TransitionPresentation,
-    TransitionPresentationInventory, UnitState, Validation,
+    linked_machines, linked_validator_entries, Branch, CanTransitionMap, CanTransitionTo,
+    CanTransitionWith, DataState, Error, LinkedMachineGraph, LinkedStateDescriptor,
+    LinkedTransitionDescriptor, LinkedTransitionInventory, LinkedValidatorEntryDescriptor,
+    MachineDescriptor, MachineGraph, MachineIntrospection, MachinePresentation,
+    MachinePresentationDescriptor, MachineStateIdentity, MachineTransitionRecorder, RebuildAttempt,
+    RebuildReport, RecordedTransition, Rejection, Result, StateDescriptor, StateMarker,
+    StatePresentation, StaticMachineLinkDescriptor, TransitionDescriptor, TransitionInventory,
+    TransitionPresentation, TransitionPresentationInventory, UnitState, Validation,
 };
 
 /// Define the legal lifecycle phases for a machine.
@@ -419,7 +419,9 @@ pub use statum_macros::__statum_emit_validator_methods_impl;
 ///   stable rejection details alongside the normal result
 ///
 /// Machine fields are available by name inside validator bodies through
-/// generated bindings. Persisted-row fields still live on `self`.
+/// generated bindings. Persisted-row fields still live on `self`. Put `#[cfg]`
+/// or `#[cfg_attr]` on the whole `#[validators]` impl, not on individual
+/// `is_{state}` methods.
 ///
 /// ```rust
 /// use statum::{machine, state, validators, Error};


### PR DESCRIPTION
## Summary
- add a canonical graph export surface for machine docs and render it as Mermaid, DOT, PlantUML, and stable JSON
- add linked codebase export that bundles linked machines, resolves direct static machine-to-machine payload links, and renders declared validator-entry nodes from compiled `#[validators]` impls
- add a `cargo statum-graph codebase <workspace-dir>` CLI that writes `codebase.mmd`, `codebase.dot`, `codebase.puml`, and `codebase.json` into the workspace root by default
- fail closed on duplicate crate-local machine paths across linked workspace members
- fail closed on method-level `#[cfg]` and `#[cfg_attr]` on validator methods so linked validator inventory only covers supported compiled impl shapes

## Testing
- cargo test -p statum-macros --test macro_errors test_invalid_validators_usage -- --exact
- cargo test -p statum-graph --test codebase --test codebase_validators
- cargo test -p cargo-statum-graph
- cargo clippy --workspace --all-targets
- cargo test --workspace

## Notes
- the codebase export is driven by linked compiled Statum registrations, not a source scan
- validator node labels use the impl self type as written in source and are display-only, not canonical Rust type identity
- builder overlays and terminal semantics remain out of scope
